### PR TITLE
Fix incorrect field numbering in IAddonSystem::Information

### DIFF
--- a/public/GarrysMod/Addon.h
+++ b/public/GarrysMod/Addon.h
@@ -15,13 +15,13 @@ namespace IAddonSystem
 	{
 		std::string title;
 		std::string file;
-		std::string placeholder1;
+		std::string tags;
+		uint64_t time_updated;
 		uint64_t wsid;
 		uint64_t creator;
-		uint64_t placeholder2;
-		uint64_t placeholder3;
+		uint64_t hcontent_file;
 		uint64_t placeholder4;
-		uint64_t placeholder5;
+		uint64_t hcontent_preview;
 		uint64_t placeholder6;
 		uint64_t placeholder7;
 		uint16_t placeholder8;


### PR DESCRIPTION
This also adds a couple of field names pulled from the SteamAPI that
match the values in the struct

Fixes #7