### PR TITLE
Changed NULL to 0 and false

### DIFF
--- a/tier1/interface.cpp
+++ b/tier1/interface.cpp
@@ -399,7 +399,7 @@ CSysModule *Sys_LoadModule( const char *pModuleName )
 	// If using the Steam filesystem, either the DLL must be a minimum footprint
 	// file in the depot (MFP) or a filesystem GetLocalCopy() call must be made
 	// prior to the call to this routine.
-	HMODULE hDLL = NULL;
+	HMODULE hDLL = 0;
 
 	char alteredFilename[ MAX_PATH ];
 	if ( IsPS3() )

--- a/tier1/memstack.cpp
+++ b/tier1/memstack.cpp
@@ -299,7 +299,7 @@ bool CMemoryStack::CommitTo( byte *pNextAlloc ) RESTRICT
 {
 	if ( m_bPhysical )
 	{
-		return NULL;
+		return false;
 	}
 
 #ifdef MEMSTACK_VIRTUAL_MEMORY_AVAILABLE


### PR DESCRIPTION
Fixed 2 errors when building sourcesdk on alpine. Compiler prohibits casting `NULL` (`std::nullptr_t`) to unsigned int and to bool.