### PR TITLE
Added missing definitions for materialsystem (x86-64 beta)

### DIFF
--- a/game/server/baseanimating.h
+++ b/game/server/baseanimating.h
@@ -15,6 +15,7 @@
 #include "studio.h"
 #include "datacache/idatacache.h"
 #include "tier0/threadtools.h"
+#include "tier0/dbg.h"
 
 
 struct animevent_t;

--- a/game/server/baseentity.h
+++ b/game/server/baseentity.h
@@ -1098,7 +1098,11 @@ public:
 #ifdef GNUC
 #define ENTITYFUNCPTR_SIZE	8
 #else
+#ifdef PLATFORM_64BITS
+#define ENTITYFUNCPTR_SIZE	8
+#else
 #define ENTITYFUNCPTR_SIZE	4
+#endif
 #endif
 
 	void FunctionCheck( void *pFunction, const char *name );

--- a/public/istudiorender.h
+++ b/public/istudiorender.h
@@ -21,6 +21,7 @@
 #include "appframework/iappsystem.h"
 #include "datacache/imdlcache.h"
 #include "studio.h"
+#include "fasttimer.h"
 
 
 //-----------------------------------------------------------------------------

--- a/public/tier0/dbg.h
+++ b/public/tier0/dbg.h
@@ -129,6 +129,8 @@ PLATFORM_INTERFACE void SetAssertDialogParent( struct SDL_Window *window );
 PLATFORM_INTERFACE struct SDL_Window * GetAssertDialogParent();
 #endif
 
+DBG_INTERFACE bool HushAsserts();
+
 /* Used to define macros, never use these directly. */
 
 #ifdef _PREFAST_

--- a/public/tier0/platform.h
+++ b/public/tier0/platform.h
@@ -278,6 +278,13 @@
 	#define PLATFORM_WINDOWS	1
     #define PLATFORM_OPENGL 0
 
+    // IsPlatformOpenGL() is used in materialsystem library. Must present on windows too.
+    #if defined( DX_TO_GL_ABSTRACTION )
+    #define IsPlatformOpenGL() true
+    #else
+    #define IsPlatformOpenGL() false
+    #endif
+
 	#ifndef _X360
 		#define IsPlatformX360() 0
 		#define IsPlatformWindowsPC() 1

--- a/public/vgui/ISurface.h
+++ b/public/vgui/ISurface.h
@@ -19,7 +19,7 @@
 
 #include "appframework/iappsystem.h"
 #include "mathlib/vector2d.h"  // must be before the namespace line
-#include "vgui/ischemesurface.h"
+//#include "vgui/ischemesurface.h"
 
 #include "IVguiMatInfo.h"
 
@@ -44,8 +44,10 @@ class IImage;
 class Image;
 class Point;
 
-
-typedef FontHandle_t HFont;
+class FontVertex_t;
+class FontCharRenderInfo;
+typedef void* FontHandle_t;
+typedef unsigned long HFont;
 typedef FontVertex_t Vertex_t;
 
 
@@ -55,6 +57,24 @@ struct IntRect
 	int y0;
 	int x1;
 	int y1;
+};
+
+enum FontDrawType_t
+{
+	// Use the "additive" value from the scheme file
+	FONT_DRAW_DEFAULT = 0,
+
+	// Overrides
+	FONT_DRAW_NONADDITIVE,
+	FONT_DRAW_ADDITIVE,
+
+	FONT_DRAW_TYPE_COUNT = 2,
+};
+
+enum FontFeatureType_t {
+	FONT_FEATURE_ANTIALIASED_FONTS = 1,
+	FONT_FEATURE_DROPSHADOW_FONTS = 2,
+	FONT_FEATURE_OUTLINE_FONTS = 6
 };
 
 struct DrawTexturedRectParms_t

--- a/public/vgui/ISurface.h
+++ b/public/vgui/ISurface.h
@@ -19,7 +19,7 @@
 
 #include "appframework/iappsystem.h"
 #include "mathlib/vector2d.h"  // must be before the namespace line
-//#include "vgui/ischemesurface.h"
+#include "vgui/ischemesurface.h"
 
 #include "IVguiMatInfo.h"
 
@@ -44,10 +44,8 @@ class IImage;
 class Image;
 class Point;
 
-class FontVertex_t;
-class FontCharRenderInfo;
-typedef void* FontHandle_t;
-typedef unsigned long HFont;
+
+typedef FontHandle_t HFont;
 typedef FontVertex_t Vertex_t;
 
 
@@ -57,24 +55,6 @@ struct IntRect
 	int y0;
 	int x1;
 	int y1;
-};
-
-enum FontDrawType_t
-{
-	// Use the "additive" value from the scheme file
-	FONT_DRAW_DEFAULT = 0,
-
-	// Overrides
-	FONT_DRAW_NONADDITIVE,
-	FONT_DRAW_ADDITIVE,
-
-	FONT_DRAW_TYPE_COUNT = 2,
-};
-
-enum FontFeatureType_t {
-	FONT_FEATURE_ANTIALIASED_FONTS = 1,
-	FONT_FEATURE_DROPSHADOW_FONTS = 2,
-	FONT_FEATURE_OUTLINE_FONTS = 6
 };
 
 struct DrawTexturedRectParms_t

--- a/public/vgui_surfacelib/ifontsurface.h
+++ b/public/vgui_surfacelib/ifontsurface.h
@@ -1,0 +1,107 @@
+//===== Copyright © 1996-2005, Valve Corporation, All rights reserved. ======//
+//
+// Purpose: 
+//
+// $NoKeywords: $
+//===========================================================================//
+
+#ifndef IFONTSURFACE_H
+#define IFONTSURFACE_H
+
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "mathlib/vector2d.h"  // must be before the namespace line
+
+#ifdef CreateFont
+#undef CreateFont
+#endif
+
+
+// returns true if the surface supports minimize & maximize capabilities
+// Numbered this way to prevent interface change in surface.
+enum FontFeature_t
+{
+	FONT_FEATURE_ANTIALIASED_FONTS	= 1,
+	FONT_FEATURE_DROPSHADOW_FONTS	= 2,
+	FONT_FEATURE_OUTLINE_FONTS	= 6,
+};
+
+// adds to the font
+enum FontFlags_t
+{
+	FONTFLAG_NONE,
+	FONTFLAG_ITALIC			= 0x001,
+	FONTFLAG_UNDERLINE		= 0x002,
+	FONTFLAG_STRIKEOUT		= 0x004,
+	FONTFLAG_SYMBOL			= 0x008,
+	FONTFLAG_ANTIALIAS		= 0x010,
+	FONTFLAG_GAUSSIANBLUR	= 0x020,
+	FONTFLAG_ROTARY			= 0x040,
+	FONTFLAG_DROPSHADOW		= 0x080,
+	FONTFLAG_ADDITIVE		= 0x100,
+	FONTFLAG_OUTLINE		= 0x200,
+	FONTFLAG_CUSTOM			= 0x400,		// custom generated font - never fall back to asian compatibility mode
+	FONTFLAG_BITMAP			= 0x800,		// compiled bitmap font - no fallbacks
+};
+
+enum FontDrawType_t
+{
+	// Use the "additive" value from the scheme file
+	FONT_DRAW_DEFAULT = 0,
+
+	// Overrides
+	FONT_DRAW_NONADDITIVE,
+	FONT_DRAW_ADDITIVE,
+
+	FONT_DRAW_TYPE_COUNT = 2,
+};	
+
+
+struct FontVertex_t
+{
+	FontVertex_t() {}
+	FontVertex_t( const Vector2D &pos, const Vector2D &coord = Vector2D( 0, 0 ) )
+	{
+		m_Position = pos;
+		m_TexCoord = coord;
+	}
+	void Init( const Vector2D &pos, const Vector2D &coord = Vector2D( 0, 0 ) )
+	{
+		m_Position = pos;
+		m_TexCoord = coord;
+	}
+	
+	Vector2D m_Position;
+	Vector2D m_TexCoord;
+};
+
+typedef unsigned long FontHandle_t;
+
+struct FontCharRenderInfo
+{
+	// Text pos
+	int				x, y;
+	// Top left and bottom right
+	// This is now a pointer to an array maintained by the surface, to avoid copying the data on the 360
+	FontVertex_t	*verts;
+	int				textureId;
+	int				abcA;
+	int				abcB;
+	int				abcC;
+	int				fontTall;
+	FontHandle_t	currentFont;
+	// In:
+	FontDrawType_t	drawType;
+	wchar_t			ch;
+
+	// Out
+	bool			valid;
+	// In/Out (true by default)
+	bool			shouldclip;
+};	
+
+
+
+#endif // IFONTSURFACE_H


### PR DESCRIPTION
After including `materialsystem/imaterialsystem.h` on windows, build will fail because IsPlatformOpenGL is missing and CFastTimer isn't implemented and used in some struct.