### PR TITLE
Changed `FileFindHandle_t` type to `intp` for compability with x86-64

### DIFF
--- a/public/filesystem.h
+++ b/public/filesystem.h
@@ -45,7 +45,7 @@ class CLanguage;
 
 typedef void * FileHandle_t;
 typedef void * FileCacheHandle_t;
-typedef int FileFindHandle_t;
+typedef intp FileFindHandle_t;
 typedef void (*FileSystemLoggingFunc_t)( const char *fileName, const char *accessType );
 typedef int WaitForResourcesHandle_t;
 


### PR DESCRIPTION
On x86-64 beta branch `IFileSystem->Find*` uses `FileFindHandle_t` as pointer, instead of index. Since `int` is smaller than pointer, it causes integer overflow, and handle becomes invalid and causes crash. Changing `int` to `intp` will fix the problem on both platforms. Also `intp` is defined in `tier0/platform.h`, so it's also cross-platform solution.