### PR TITLE
Updated Command Completion. (64 -> 128)

### DIFF
--- a/public/tier1/convar.h
+++ b/public/tier1/convar.h
@@ -69,8 +69,8 @@ void ConVar_PublishToVXConsole();
 typedef void ( *FnCommandCallbackVoid_t )( void );
 typedef void ( *FnCommandCallback_t )( const CCommand &command );
 
-#define COMMAND_COMPLETION_MAXITEMS		64
-#define COMMAND_COMPLETION_ITEM_LENGTH	64
+#define COMMAND_COMPLETION_MAXITEMS		128
+#define COMMAND_COMPLETION_ITEM_LENGTH	128
 
 //-----------------------------------------------------------------------------
 // Returns 0 to COMMAND_COMPLETION_MAXITEMS worth of completion strings


### PR DESCRIPTION
While working on a project, I noticed that FnCommandCompletionCallback was incompatible with 
`int (*)(char const*, char (*)[128])` because `COMMAND_COMPLETION_MAXITEMS` was raised to 128 along with `COMMAND_COMPLETION_ITEM_LENGTH`.