### PR TITLE
Fix for a failing assertion on x64 linux gcc builds and C++ 20 compatibility

### DIFF
--- a/game/server/baseentity.h
+++ b/game/server/baseentity.h
@@ -1095,15 +1095,7 @@ public:
 	// Ugly code to lookup all functions to make sure they are in the table when set.
 #ifdef _DEBUG
 
-#ifdef GNUC
-#define ENTITYFUNCPTR_SIZE	8
-#else
-#ifdef PLATFORM_64BITS
-#define ENTITYFUNCPTR_SIZE	8
-#else
-#define ENTITYFUNCPTR_SIZE	4
-#endif
-#endif
+#define ENTITYFUNCPTR_SIZE sizeof(ENTITYFUNCPTR)
 
 	void FunctionCheck( void *pFunction, const char *name );
 	ENTITYFUNCPTR TouchSet( ENTITYFUNCPTR func, char *name ) 

--- a/public/tier1/utlsymbol.h
+++ b/public/tier1/utlsymbol.h
@@ -118,7 +118,7 @@ public:
 
 	inline bool HasElement(const char* pStr) const
 	{
-		return Find(pStr) != UTL_INVAL_SYMBOL;
+		return static_cast<UtlSymId_t>(Find(pStr)) != UTL_INVAL_SYMBOL;
 	}
 	
 	// Remove all symbols in the table.


### PR DESCRIPTION
The assertion would always fail on linux x64 gcc builds.

The latter problem is disambiguating a cast that errors on C++20