### PR TITLE
Fixed C++20 syntax errors

### DIFF
--- a/public/tier0/threadtools.h
+++ b/public/tier0/threadtools.h
@@ -866,8 +866,8 @@ private:
 	MUTEX_TYPE &m_lock;
 
 	// Disallow copying
-	CAutoLockT<MUTEX_TYPE>( const CAutoLockT<MUTEX_TYPE> & );
-	CAutoLockT<MUTEX_TYPE> &operator=( const CAutoLockT<MUTEX_TYPE> & );
+	CAutoLockT( const CAutoLockT & );
+	CAutoLockT &operator=( const CAutoLockT & );
 };
 
 typedef CAutoLockT<CThreadMutex> CAutoLock;

--- a/public/tier1/datamanager.h
+++ b/public/tier1/datamanager.h
@@ -133,10 +133,9 @@ class CDataManager : public CDataManagerBase
 	typedef CDataManagerBase BaseClass;
 public:
 
-	CDataManager<STORAGE_TYPE, CREATE_PARAMS, LOCK_TYPE, MUTEX_TYPE>( unsigned int size = (unsigned)-1 ) : BaseClass(size) {}
-	
+	CDataManager( unsigned int size = (unsigned)-1 ) : BaseClass(size) {}
 
-	~CDataManager<STORAGE_TYPE, CREATE_PARAMS, LOCK_TYPE, MUTEX_TYPE>()
+	~CDataManager()
 	{
 		// NOTE: This must be called in all implementations of CDataManager
 		FreeAllLists();


### PR DESCRIPTION
I originally fixed this on the x64 branch but thought it should be pushed to master first. This is compatible with prior C++ versions.