### PR TITLE
Replace _flag1 in CBaseFileSystem::CSearchPath with the correct type

### DIFF
--- a/public/filesystem_base.h
+++ b/public/filesystem_base.h
@@ -47,6 +47,24 @@ enum FileType_t
 	FT_PACK_TEXT
 };
 
+enum CPathGroupName_t
+{
+	GN_DEFAULT,
+	GN_ENGINECORE,
+	GN_LUA,
+	GN_MAP,
+	GN_ADDONCONTENT,
+	GN_GMCONTENT,
+	GN_GMODCORE,
+	GN_CURRENTGAME,
+	GN_SOURCESDK,
+	GN_BADDONCONTENT,
+	GN_GAMECONTENT,
+	GN_MOUNTCFG,
+	GN_DOWNLOADS,
+	GN_FALLBACKS
+};
+
 union Placeholder4
 {
 	const uint8_t bytes[4];
@@ -493,7 +511,7 @@ public:
 		int32_t m_storeId;
 		CPathIDInfo *m_pPathIDInfo;
 		uint32_t _flag0;
-		uint32_t _flag1;
+		CPathGroupName_t m_GroupID;
 		CUtlSymbol m_Path;
 		const char *m_pDebugPath;
 		CPackFile *m_pPackFile;


### PR DESCRIPTION
This flag is used in `CBaseFileSystem::PrintSearchPaths` and responsible for the groups when outputting the list (`...("--- %s ---\n", GMOD_GetSearchPathGroupName(int)::names[cpath + 12])...`).

Example:
![img1](https://github.com/user-attachments/assets/d46a114a-0b39-4f4b-b0d0-0c561cd7cf67)
![img2](https://github.com/user-attachments/assets/d73b9da5-3d95-41bf-a3ac-b1874cf67ec3)
