### PR TITLE
Some 64x fixes

### DIFF
--- a/common/input_device.h
+++ b/common/input_device.h
@@ -1,0 +1,80 @@
+//========= Copyright 2012, Valve Corporation, All rights reserved. ============//
+//
+// Purpose: 
+//
+// $NoKeywords: $
+//
+//=============================================================================//
+
+#ifndef INPUT_DEVICES_H
+#define INPUT_DEVICES_H
+
+#ifdef _WIN32
+#pragma once
+#endif
+#if defined( _PS3 )
+#include <limits.h>
+#endif
+
+
+
+// [dkorus]:  The values here are setup to be used as a bit-field.  
+//			for example: A PS3 with a KEYBOARD_MOUSE attached as well as a PLAYSTATION_MOVE would have a connected 
+//			device bitfield of 5 (4 for playstation move, 1 for the keyboard/mouse, for 4+1==5)
+//			when adding new entries, make sure they are a power of 2.
+
+enum InputDevice_t
+{
+	INPUT_DEVICE_NONE				= 0,			// (0) no specific device is selected
+	INPUT_DEVICE_KEYBOARD_MOUSE		= 1 << 0,		// (1) considered connected if BOTH INPUT_DEVICE_KEYBOARD and INPUT_DEVICE_MOUSE are connected
+	INPUT_DEVICE_GAMEPAD			= 1 << 1,		// (2) includes PS3, XBox360, or 360 gamepad connected to PC
+	INPUT_DEVICE_PLAYSTATION_MOVE	= 1 << 2,		// (4) PS3 only
+	INPUT_DEVICE_HYDRA				= 1 << 3,		// (8) support on PC
+	INPUT_DEVICE_SHARPSHOOTER		= 1 << 4,		// (16) PS3 only
+	INPUT_DEVICE_MOVE_NAV_CONTROLLER = 1 << 5,		// (32) PS3 only
+	INPUT_DEVICE_STEAM_CONTROLLER 	= 1 << 6,		// (64) Steam controller
+
+	INPUT_DEVICE_MAX,
+	INPUT_DEVICE_INVALID = INPUT_DEVICE_MAX,
+	INPUT_DEVICE_FORCE_INT32		= INT32_MAX
+};
+
+DEFINE_ENUM_BITWISE_OPERATORS( InputDevice_t )
+
+
+// [mpritchard]:  When we are talking about input devices, we also have an implicit, or explicit, platform
+//     that we are talking about because the list of possible input devices is specific to and varies by the
+//     the platform of the player.   We can't just use the platform that the code is compiled for because
+//     some code which may be running on a dedicated server which can be a platform than the clients:
+//	   Specifically, that the dedicated server for Xbox360 and PS3 clients is compiled for and runs on
+//      either a windows PC or LINUX.   For this reason, we need a server on one platform to be able ask
+//      what are the valid input devices for this other platform...
+//
+enum InputDevicePlatform_t
+{
+	INPUT_DEVICE_PLATFORM_ANY       = -2,
+	INPUT_DEVICE_PLATFORM_LOCAL     = -1,
+	INPUT_DEVICE_PLATFORM_NONE		= 0,		// Allows for a undefined platform
+	INPUT_DEVICE_PLATFORM_WINDOWS,
+	INPUT_DEVICE_PLATFORM_OSX,
+	INPUT_DEVICE_PLATFORM_XBOX360,
+	INPUT_DEVICE_PLATFORM_PS3,
+	INPUT_DEVICE_PLATFORM_LINUX,
+
+	INPUT_DEVICE_PLATFORM_COUNT,		// list auto counter
+	INPUT_DEVICE_PLATFORM_FORCE_INT32	= INT32_MAX
+};
+
+// motion controller state
+enum InputDeviceMCState
+{
+	INPUT_DEVICE_MC_STATE_CAMERA_NOT_CONNECTED = -1,
+	INPUT_DEVICE_MC_STATE_CONTROLLER_NOT_CONNECTED,
+	INPUT_DEVICE_MC_STATE_CONTROLLER_NOT_CALIBRATED,
+	INPUT_DEVICE_MC_STATE_CONTROLLER_CALIBRATING,
+	INPUT_DEVICE_MC_STATE_CONTROLLER_ERROR,
+	INPUT_DEVICE_MC_STATE_OK,
+};
+
+
+#endif //INPUT_DEVICES_H

--- a/public/bitmap/imageformat_declarations.h
+++ b/public/bitmap/imageformat_declarations.h
@@ -123,7 +123,7 @@ enum ImageFormat
 
 
 
-#if defined( DX_TO_GL_ABSTRACTION ) || defined( _PS3 )
+#if defined( DX_TO_GL_ABSTRACTION ) || defined( _PS3 ) || defined( POSIX )
 typedef enum _D3DFORMAT
 	{
 		D3DFMT_INDEX16,

--- a/public/networkvar.h
+++ b/public/networkvar.h
@@ -54,7 +54,8 @@
 // network vars use memcmp when fields are set.  To ensure proper behavior your
 // object's memory should be initialized to zero.  This happens for entities automatically
 // use this for other classes.
-class CMemZeroOnNew
+// RaphaelIT7: This class is not even used and caused compile errors.....
+/*class CMemZeroOnNew
 {
 public:
 	void *operator new( size_t nSize )
@@ -86,7 +87,7 @@ public:
 			g_pMemAlloc->Free(pData, pFileName, nLine );
 		}
 	}
-};
+};*/
 
 
 inline int InternalCheckDeclareClass( const char *pClassName, const char *pClassNameMatch, void *pTestPtr, void *pBasePtr )

--- a/public/tier0/platform.h
+++ b/public/tier0/platform.h
@@ -349,6 +349,7 @@
 	#define IsPlatformWindowsPC32()	0
 	#define IsPlatformPosix()		1
 	#define PLATFORM_POSIX 1
+	#define IsPlatformOpenGL()		false
 
 	#if defined( LINUX ) && !defined( OSX ) // for havok we define both symbols, so don't let the osx build wander down here
 		#define IsPlatformLinux() 1

--- a/public/tier0/tslist.h
+++ b/public/tier0/tslist.h
@@ -96,50 +96,6 @@ inline bool ThreadInterlockedAssignIf128( int128 volatile * pDest, const int128 
     // so operate on a local copy.
     int128 local_comparand = comparand;
 	return __sync_bool_compare_and_swap_16_sdk( pDest, local_comparand, value );
-
-	volatile __int128_t* ptr = pDest;
-	__int128_t oldval = local_comparand;
-	__int128_t newval = value;
-	{
-		bool result;
-
-		union par128
-		{
-			__int128_t f;
-			struct {
-				uint64_t l;
-				uint64_t h;
-			} s;
-		};
-		union par128 old;
-		union par128 neww;
-		old.f = oldval;
-		neww.f = newval;
-
-		__asm__ __volatile__
-		(
-			"lock cmpxchg16b %1\n\t"
-			"setz %0"
-			: "=q" (result),
-			"+m" (*ptr),
-			"+d" (old.s.h),
-			"+a" (old.s.l)
-			: "c"  (neww.s.h),
-			"b"  (neww.s.l)
-			: "cc"
-		);
-
-	#if 0
-		if (!result) {
-			debug_printf("%s: failed (ptr = %p, oldval = [%lx, %lx], "
-				"newval = [%lx, %lx])\n",
-				__FUNCTION__, (void*)ptr,
-				old.s.l, old.s.h, neww.s.l, neww.s.h);
-		}
-	#endif
-
-		return result;
-	}
 }
 #endif
 

--- a/public/tier0/tslist.h
+++ b/public/tier0/tslist.h
@@ -48,12 +48,98 @@ typedef __int128_t int128;
 #define TSLIST_NODE_ALIGNMENT 16
 
 #ifdef POSIX
+inline bool __sync_bool_compare_and_swap_16_sdk(volatile __int128_t* ptr, __int128_t oldval, __int128_t newval)
+{
+	bool result;
+
+	union par128
+	{
+		__int128_t f;
+		struct {
+			uint64_t l;
+			uint64_t h;
+		} s;
+	};
+	union par128 old;
+	union par128 neww;
+	old.f = oldval;
+	neww.f = newval;
+
+	__asm__ __volatile__
+	(
+		"lock cmpxchg16b %1\n\t"
+		"setz %0"
+		: "=q" (result),
+		"+m" (*ptr),
+		"+d" (old.s.h),
+		"+a" (old.s.l)
+		: "c"  (neww.s.h),
+		"b"  (neww.s.l)
+		: "cc"
+	);
+
+#if 0
+	if (!result) {
+		debug_printf("%s: failed (ptr = %p, oldval = [%lx, %lx], "
+			"newval = [%lx, %lx])\n",
+			__FUNCTION__, (void*)ptr,
+			old.s.l, old.s.h, neww.s.l, neww.s.h);
+	}
+#endif
+
+	return result;
+}
+
 inline bool ThreadInterlockedAssignIf128( int128 volatile * pDest, const int128 &value, const int128 &comparand ) 
 {
     // We do not want the original comparand modified by the swap
     // so operate on a local copy.
     int128 local_comparand = comparand;
-	return __sync_bool_compare_and_swap( pDest, local_comparand, value );
+	return __sync_bool_compare_and_swap_16_sdk( pDest, local_comparand, value );
+
+	volatile __int128_t* ptr = pDest;
+	__int128_t oldval = local_comparand;
+	__int128_t newval = value;
+	{
+		bool result;
+
+		union par128
+		{
+			__int128_t f;
+			struct {
+				uint64_t l;
+				uint64_t h;
+			} s;
+		};
+		union par128 old;
+		union par128 neww;
+		old.f = oldval;
+		neww.f = newval;
+
+		__asm__ __volatile__
+		(
+			"lock cmpxchg16b %1\n\t"
+			"setz %0"
+			: "=q" (result),
+			"+m" (*ptr),
+			"+d" (old.s.h),
+			"+a" (old.s.l)
+			: "c"  (neww.s.h),
+			"b"  (neww.s.l)
+			: "cc"
+		);
+
+	#if 0
+		if (!result) {
+			debug_printf("%s: failed (ptr = %p, oldval = [%lx, %lx], "
+				"newval = [%lx, %lx])\n",
+				__FUNCTION__, (void*)ptr,
+				old.s.l, old.s.h, neww.s.l, neww.s.h);
+		}
+	#endif
+
+		return result;
+	}
 }
 #endif
 

--- a/public/tier0/tslist.h
+++ b/public/tier0/tslist.h
@@ -48,54 +48,12 @@ typedef __int128_t int128;
 #define TSLIST_NODE_ALIGNMENT 16
 
 #ifdef POSIX
-inline bool __sync_bool_compare_and_swap_16_sdk(volatile __int128_t* ptr, __int128_t oldval, __int128_t newval)
-{
-	bool result;
-
-	union par128
-	{
-		__int128_t f;
-		struct {
-			uint64_t l;
-			uint64_t h;
-		} s;
-	};
-	union par128 old;
-	union par128 neww;
-	old.f = oldval;
-	neww.f = newval;
-
-	__asm__ __volatile__
-	(
-		"lock cmpxchg16b %1\n\t"
-		"setz %0"
-		: "=q" (result),
-		"+m" (*ptr),
-		"+d" (old.s.h),
-		"+a" (old.s.l)
-		: "c"  (neww.s.h),
-		"b"  (neww.s.l)
-		: "cc"
-	);
-
-#if 0
-	if (!result) {
-		debug_printf("%s: failed (ptr = %p, oldval = [%lx, %lx], "
-			"newval = [%lx, %lx])\n",
-			__FUNCTION__, (void*)ptr,
-			old.s.l, old.s.h, neww.s.l, neww.s.h);
-	}
-#endif
-
-	return result;
-}
-
 inline bool ThreadInterlockedAssignIf128( int128 volatile * pDest, const int128 &value, const int128 &comparand ) 
 {
     // We do not want the original comparand modified by the swap
     // so operate on a local copy.
     int128 local_comparand = comparand;
-	return __sync_bool_compare_and_swap_16_sdk( pDest, local_comparand, value );
+	return __sync_bool_compare_and_swap( pDest, local_comparand, value );
 }
 #endif
 

--- a/public/tier0/vprof.h
+++ b/public/tier0/vprof.h
@@ -667,7 +667,7 @@ public:
 	void HideBudgetGroup( int budgetGroupID, bool bHide = true );
 	void HideBudgetGroup( const tchar *pszName, bool bHide = true ) { HideBudgetGroup( BudgetGroupNameToBudgetGroupID( pszName), bHide ); }
 
-	int64 *FindOrCreateCounter( const tchar *pName, CounterGroup_t eCounterGroup=COUNTER_GROUP_DEFAULT  );
+	int *FindOrCreateCounter( const tchar *pName, CounterGroup_t eCounterGroup=COUNTER_GROUP_DEFAULT  );
 	void ResetCounters( CounterGroup_t eCounterGroup );
 	
 	int GetNumCounters( void ) const;
@@ -1425,7 +1425,7 @@ public:
 		*m_pCounter = val; 
 	}
 private:
-	int64 *m_pCounter;
+	int *m_pCounter;
 };
 
 #endif

--- a/tier1/interface.cpp
+++ b/tier1/interface.cpp
@@ -401,22 +401,6 @@ CSysModule *Sys_LoadModule( const char *pModuleName )
 	// prior to the call to this routine.
 	HMODULE hDLL = 0;
 
-	char alteredFilename[ MAX_PATH ];
-	if ( IsPS3() )
-	{
-		// PS3's load module *must* be fed extensions. If the extension is missing, add it. 
-		if (!( strstr(pModuleName, ".sprx") || strstr(pModuleName, ".prx") ))
-		{
-			strncpy( alteredFilename, pModuleName, MAX_PATH );
-			strncat( alteredFilename, DLL_EXT_STRING, MAX_PATH );
-			pModuleName = alteredFilename;
-		}
-	}
-	else
-	{
-		(void)alteredFilename; // just to quash the warning
-	}
-
 	if ( !Q_IsAbsolutePath( pModuleName ) )
 	{
 		// full path wasn't passed in, using the current working dir

--- a/tier1/interface.cpp
+++ b/tier1/interface.cpp
@@ -401,6 +401,22 @@ CSysModule *Sys_LoadModule( const char *pModuleName )
 	// prior to the call to this routine.
 	HMODULE hDLL = 0;
 
+	char alteredFilename[ MAX_PATH ];
+	if ( IsPlatformPS3() )
+	{
+		// PS3's load module *must* be fed extensions. If the extension is missing, add it. 
+		if (!( strstr(pModuleName, ".sprx") || strstr(pModuleName, ".prx") ))
+		{
+			strncpy( alteredFilename, pModuleName, MAX_PATH );
+			strncat( alteredFilename, DLL_EXT_STRING, MAX_PATH );
+			pModuleName = alteredFilename;
+		}
+	}
+	else
+	{
+		(void)alteredFilename; // just to quash the warning
+	}
+
 	if ( !Q_IsAbsolutePath( pModuleName ) )
 	{
 		// full path wasn't passed in, using the current working dir


### PR DESCRIPTION
Solved some 64x funnies

\- [+] Added missing `input_device.h` file - I lost its original source :(
\- [+] Added `__sync_bool_compare_and_swap_16_sdk` - It solved some issue I had months ago but I forgot what exactly :(

\- [#] Fixed `_D3DFORMAT` and `IsPlatformOpenGL` missing on Linux
\- [#] Changed `CVProfile::FindOrCreateCounter` to use a `int` instead of `uint64`
\- [-] Removed `PS3` code in `Sys_LoadModule` as Gmod doesn't have it.
\- [-] Commented out `CMemZeroOnNew` as it created compile errors(`g_pMemAlloc` being undefined) and it isn't even used anywhere.