### PR TITLE
GMod Update

### DIFF
--- a/engine/baseclient.h
+++ b/engine/baseclient.h
@@ -184,8 +184,8 @@ public:
 	void			CheckFlushNameChange( bool bShowStatusMessage = false );
 	bool			IsNameChangeOnCooldown( bool bShowStatusMessage = false );
 
-	void			SetPlayerNameLocked( bool bValue ) { m_bPlayerNameLocked = bValue; }
-	bool			IsPlayerNameLocked( void ) { return m_bPlayerNameLocked; }
+	// void			SetPlayerNameLocked( bool bValue ) { m_bPlayerNameLocked = bValue; }
+	// bool			IsPlayerNameLocked( void ) { return m_bPlayerNameLocked; }
 
 	void			SetSignOnState( int ); // Why
 
@@ -205,12 +205,12 @@ public:
 	char			m_Name[MAX_PLAYER_NAME_LENGTH];			// for printing to other people
 	char			m_GUID[SIGNED_GUID_LEN + 1]; // the clients CD key
 
-/*#if ARCHITECTURE_IS_X86_64
+#if PLATFORM_64BITS
 	// CNETMsg_PlayerAvatarData_t m_msgAvatarData;	// Client avatar
 	// RaphaelIT7: This are the offsets for the variable above. Why not add it directly? Because it depends on sooo much it would be a pain to do. Maybe if I'm bored I'll do it.
 	int _offset[23];
 	char _offset2;
-#endif*/
+#endif
 
 	CSteamID		m_SteamID;			// This is valid when the client is authenticated
 	
@@ -219,7 +219,9 @@ public:
 
 	KeyValues		*m_ConVars;			// stores all client side convars
 	bool			m_bConVarsChanged;	// true if convars updated and not changes process yet
+#if PLATFORM_64BITS
 	bool			m_bInitialConVarsSet; // Has the client sent their initial set of convars
+#endif
 	bool			m_bSendServerInfo;	// true if we need to send server info packet to start connect
 	CBaseServer		*m_Server;			// pointer to server object
 	bool			m_bIsHLTV;			// if this a HLTV proxy ?
@@ -255,10 +257,10 @@ public:
 	// until we get an ack from them on this packet.
 	// This is for 3 reasons:
 	// 1. A client requesting a nodelta packet means they're screwed so no point in deluging them with data.
-	//    Better to send the uncompressed data at a slow rate until we hear back from them (if at all).
+	//	Better to send the uncompressed data at a slow rate until we hear back from them (if at all).
 	// 2. Since the nodelta packet deletes all client entities, we can't ever delta from a packet previous to it.
 	// 3. It can eat up a lot of CPU on the server to keep building nodelta packets while waiting for
-	//    a client to get back on its feet.
+	//	a client to get back on its feet.
 	int				m_nForceWaitForTick;
 	
 	bool			m_bFakePlayer;		// JAC: This client is a fake player controlled by the game DLL
@@ -269,7 +271,7 @@ public:
 
 	// Time when last name change was applied
 	double			m_fTimeLastNameChange;
-	bool			m_bPlayerNameLocked;
+	// bool			m_bPlayerNameLocked;
 
 	// Does this client have a name change that is pending?
 	// (Their 'name' convar differs from our value for their client name.)
@@ -279,16 +281,13 @@ public:
 	// when it is sent out to the client.  overflow is tolerated.
 
 	// Time when we should send next world state update ( datagram )
-	double         m_fNextMessageTime;   
+	double		 m_fNextMessageTime;   
 	// Default time to wait for next message
-	float          m_fSnapshotInterval;  
+	float		  m_fSnapshotInterval;  
 
-	enum
-	{
-		SNAPSHOT_SCRATCH_BUFFER_SIZE = 160000,
-	};
+	static constexpr uint32_t SNAPSHOT_SCRATCH_BUFFER_SIZE = 1048576;
 
-	unsigned int		m_SnapshotScratchBuffer[ SNAPSHOT_SCRATCH_BUFFER_SIZE / 4 ];
+	CSteamID m_OwnerSteamID; // Verify: Could be owner steamid for Player:OwnerSteamID64()
 
 private:
 	void				StartTrace( bf_write &msg );
@@ -297,8 +296,8 @@ private:
 
 	int					m_iTracing; // 0 = not active, 1 = active for this frame, 2 = forced active
 	CNetworkStatTrace	m_Trace;
+
+	void* __offset2[4];
 };
-
-
 
 #endif // BASECLIENT_H

--- a/engine/baseclient.h
+++ b/engine/baseclient.h
@@ -184,9 +184,6 @@ public:
 	void			CheckFlushNameChange( bool bShowStatusMessage = false );
 	bool			IsNameChangeOnCooldown( bool bShowStatusMessage = false );
 
-	// void			SetPlayerNameLocked( bool bValue ) { m_bPlayerNameLocked = bValue; }
-	// bool			IsPlayerNameLocked( void ) { return m_bPlayerNameLocked; }
-
 	void			SetSignOnState( int ); // Why
 
 private:	
@@ -257,10 +254,10 @@ public:
 	// until we get an ack from them on this packet.
 	// This is for 3 reasons:
 	// 1. A client requesting a nodelta packet means they're screwed so no point in deluging them with data.
-	//	Better to send the uncompressed data at a slow rate until we hear back from them (if at all).
+	//    Better to send the uncompressed data at a slow rate until we hear back from them (if at all).
 	// 2. Since the nodelta packet deletes all client entities, we can't ever delta from a packet previous to it.
 	// 3. It can eat up a lot of CPU on the server to keep building nodelta packets while waiting for
-	//	a client to get back on its feet.
+	//    a client to get back on its feet.
 	int				m_nForceWaitForTick;
 	
 	bool			m_bFakePlayer;		// JAC: This client is a fake player controlled by the game DLL
@@ -271,7 +268,6 @@ public:
 
 	// Time when last name change was applied
 	double			m_fTimeLastNameChange;
-	// bool			m_bPlayerNameLocked;
 
 	// Does this client have a name change that is pending?
 	// (Their 'name' convar differs from our value for their client name.)
@@ -281,11 +277,14 @@ public:
 	// when it is sent out to the client.  overflow is tolerated.
 
 	// Time when we should send next world state update ( datagram )
-	double		 m_fNextMessageTime;   
+	double         m_fNextMessageTime;   
 	// Default time to wait for next message
-	float		  m_fSnapshotInterval;  
+	float          m_fSnapshotInterval;  
 
-	static constexpr uint32_t SNAPSHOT_SCRATCH_BUFFER_SIZE = 1048576;
+	enum
+	{
+		SNAPSHOT_SCRATCH_BUFFER_SIZE = 1048576,
+	};
 
 	CSteamID m_OwnerSteamID; // Verify: Could be owner steamid for Player:OwnerSteamID64()
 
@@ -299,5 +298,7 @@ private:
 
 	void* __offset2[4];
 };
+
+
 
 #endif // BASECLIENT_H

--- a/engine/baseserver.h
+++ b/engine/baseserver.h
@@ -67,7 +67,7 @@ public: // IServer implementation
 	virtual int		GetUDPPort( void ) const { return NET_GetUDPPort( m_Socket );	}
 	virtual IClient	*GetClient( int index ) { return m_Clients[index]; } // returns interface to client 
 	virtual int		GetClientCount() const { return m_Clients.Count(); } // for iteration;
-	virtual float	GetTime( void ) const;
+	virtual double	GetTime( void ) const;
 	virtual int		GetTick( void ) const { return m_nTickCount; }
 	virtual float	GetTickInterval( void ) const { return m_flTickInterval; }
 	virtual const char *GetName( void ) const;

--- a/engine/net.h
+++ b/engine/net.h
@@ -24,7 +24,7 @@
 
 #define SIGNON_TIME_OUT				300.0f  // signon disconnect timeout
 
-#define FRAGMENT_BITS		8
+#define FRAGMENT_BITS		12
 #define FRAGMENT_SIZE		(1<<FRAGMENT_BITS)
 #define MAX_FILE_SIZE_BITS	26
 #define MAX_FILE_SIZE		((1<<MAX_FILE_SIZE_BITS)-1)	// maximum transferable size is	64MB

--- a/engine/net_chan.h
+++ b/engine/net_chan.h
@@ -1,14 +1,11 @@
 //========= Copyright Valve Corporation, All rights reserved. ============//
 //
-// Purpose: net_chan.h
+// Purpose: 
 //
-//=============================================================================//
+// $NoKeywords: $
+//===========================================================================//
 
-#ifndef NET_CHAN_H
-#define NET_CHAN_H
-#ifdef _WIN32
 #pragma once
-#endif
 
 #include "net.h"
 #include "netadr.h"
@@ -27,24 +24,16 @@
 #define FLOW_INTERVAL 0.25F
 
 
-#define NET_FRAMES_BACKUP	64	// must be power of 2
+#define NET_FRAMES_BACKUP	64		// must be power of 2
 #define NET_FRAMES_MASK		(NET_FRAMES_BACKUP-1)
 
-// RaphaelIT7: log function for constexpr numbers - mainly used to figure out how many bits for networking are needed for a limit
-constexpr int RequiredBits(int v)
-{
-    int bits = 0;
-    while ((1 << bits) < v)
-        ++bits;
 
-    return bits;
-}
+#define MAX_SUBCHANNELS_BITS	4
+#define MAX_SUBCHANNELS			(1 << MAX_SUBCHANNELS_BITS)		// we have N alternative send&wait channels
 
-constexpr int MAX_SUBCHANNELS = 16;	// we have x alternative send&wait channels
-constexpr int SUBCHANNEL_BITS = RequiredBits(MAX_SUBCHANNELS);
+#define MAX_FRAGMENTS_BITS		5								// How many fragments we can send at once
+#define MAX_FRAGMENTS			(1 << MAX_FRAGMENTS_BITS) - 1	// Maximum number of fragments we can safely transmit. -1 as else we would go over MAX_FRAGMENTS_BITS
 
-constexpr int MAX_FRAGMENTS_BITS = 5;	// How many fragments we can send at once
-constexpr int MAX_FRAGMENTS = (1 << MAX_FRAGMENTS_BITS) - 1;  // Maximum number of fragments we can safely transmit. -1 as else we would go over MAX_FRAGMENTS_BITS
 
 #define SUBCHANNEL_FREE		0	// subchannel is free to use
 #define SUBCHANNEL_TOSEND	1	// subchannel has data, but not send yet
@@ -311,7 +300,7 @@ public:
 	// For timeouts.  Time last message was received.
 	float		last_received;		
 	// Time when channel was connected.
-	double	  connect_time;	   
+	double      connect_time;	   
 
 	// Bandwidth choke
 	// Bytes per second
@@ -364,6 +353,3 @@ public:
 
 	int							m_nProtocolVersion;		// PROTOCOL_VERSION if we're not playing a demo - otherwise, whatever was in the demo header's networkprotocol if the CNetChan instance was created by a demo player.
 };
-
-
-#endif // NET_CHAN_H

--- a/engine/net_chan.h
+++ b/engine/net_chan.h
@@ -1,9 +1,14 @@
 //========= Copyright Valve Corporation, All rights reserved. ============//
 //
-// Purpose: 
+// Purpose: net_chan.h
 //
-// $NoKeywords: $
-//===========================================================================//
+//=============================================================================//
+
+#ifndef NET_CHAN_H
+#define NET_CHAN_H
+#ifdef _WIN32
+#pragma once
+#endif
 
 #include "net.h"
 #include "netadr.h"
@@ -22,9 +27,24 @@
 #define FLOW_INTERVAL 0.25F
 
 
-#define NET_FRAMES_BACKUP	64		// must be power of 2
+#define NET_FRAMES_BACKUP	64	// must be power of 2
 #define NET_FRAMES_MASK		(NET_FRAMES_BACKUP-1)
-#define MAX_SUBCHANNELS		8		// we have 8 alternative send&wait bits
+
+// RaphaelIT7: log function for constexpr numbers - mainly used to figure out how many bits for networking are needed for a limit
+constexpr int RequiredBits(int v)
+{
+    int bits = 0;
+    while ((1 << bits) < v)
+        ++bits;
+
+    return bits;
+}
+
+constexpr int MAX_SUBCHANNELS = 16;	// we have x alternative send&wait channels
+constexpr int SUBCHANNEL_BITS = RequiredBits(MAX_SUBCHANNELS);
+
+constexpr int MAX_FRAGMENTS_BITS = 5;	// How many fragments we can send at once
+constexpr int MAX_FRAGMENTS = (1 << MAX_FRAGMENTS_BITS) - 1;  // Maximum number of fragments we can safely transmit. -1 as else we would go over MAX_FRAGMENTS_BITS
 
 #define SUBCHANNEL_FREE		0	// subchannel is free to use
 #define SUBCHANNEL_TOSEND	1	// subchannel has data, but not send yet
@@ -50,7 +70,7 @@ public: // netchan structurs
 		bool			asTCP;			// send as TCP stream
 		int				numFragments;	// number of total fragments
 		int				ackedFragments; // number of fragments send & acknowledged
-		int				pendingFragments; // number of fragments send, but not acknowledged yet
+		int				pendingFragments; // number of fragments send, but not acknowledged yet. Filled with junk in the m_ReceiveList as it's fully unused there
 	} dataFragments_t;
 
 	struct subChannel_s
@@ -256,7 +276,7 @@ public:
 	int			m_nOutSequenceNr;
 	// last received incoming sequnec number
 	int			m_nInSequenceNr;
-	// last received acknowledge outgoing sequnce number
+	// last received acknowledge outgoing sequence number
 	int			m_nOutSequenceNrAck;
 	
 	// state of outgoing reliable data (0/1) flip flop used for loss detection
@@ -291,7 +311,7 @@ public:
 	// For timeouts.  Time last message was received.
 	float		last_received;		
 	// Time when channel was connected.
-	double      connect_time;       
+	double	  connect_time;	   
 
 	// Bandwidth choke
 	// Bytes per second
@@ -304,7 +324,7 @@ public:
 	subChannel_s					m_SubChannels[MAX_SUBCHANNELS];
 
 	unsigned int	m_FileRequestCounter;	// increasing counter with each file request
-	bool			m_bFileBackgroundTranmission; // if true, only send 1 fragment per packet
+	bool			m_bFileBackgroundTransmission; // if true, only send 1 fragment per packet
 	bool			m_bUseCompression;	// if true, larger reliable data will be bzip compressed
 	
 	// TCP stream state maschine:
@@ -344,3 +364,6 @@ public:
 
 	int							m_nProtocolVersion;		// PROTOCOL_VERSION if we're not playing a demo - otherwise, whatever was in the demo header's networkprotocol if the CNetChan instance was created by a demo player.
 };
+
+
+#endif // NET_CHAN_H

--- a/game/client/baseanimatedtextureproxy.h
+++ b/game/client/baseanimatedtextureproxy.h
@@ -29,7 +29,7 @@ public:
 protected:
 	// derived classes must implement this; it returns the time
 	// that the animation began
-	virtual float  GetAnimationStartTime( void* pBaseEntity ) = 0;
+	virtual double  GetAnimationStartTime( void* pBaseEntity ) = 0;
 
 	// Derived classes may implement this if they choose;
 	// this method is called whenever the animation wraps...

--- a/game/client/c_ai_basenpc.h
+++ b/game/client/c_ai_basenpc.h
@@ -33,27 +33,18 @@ public:
 
 	int						GetDeathPose( void ) { return m_iDeathPose; }
 
-	bool					ShouldModifyPlayerSpeed( void ) { return m_bSpeedModActive;	}
-	int						GetSpeedModifyRadius( void ) { return m_iSpeedModRadius; }
-	int						GetSpeedModifySpeed( void ) { return m_iSpeedModSpeed;	}
-
 	void					ClientThink( void );
 	void					OnDataChanged( DataUpdateType_t type );
 	bool					ImportantRagdoll( void ) { return m_bImportanRagdoll;	}
 
 private:
 	C_AI_BaseNPC( const C_AI_BaseNPC & ); // not defined, not accessible
-	float m_flTimePingEffect;
 	int  m_iDeathPose;
 	int	 m_iDeathFrame;
-
-	int m_iSpeedModRadius;
-	int m_iSpeedModSpeed;
 
 	bool m_bPerformAvoidance;
 	bool m_bIsMoving;
 	bool m_bFadeCorpse;
-	bool m_bSpeedModActive;
 	bool m_bImportanRagdoll;
 };
 

--- a/game/client/c_baseanimating.h
+++ b/game/client/c_baseanimating.h
@@ -109,7 +109,7 @@ public:
 
 	bool UsesPowerOfTwoFrameBufferTexture( void );
 
-	virtual bool	Interpolate( float currentTime );
+	virtual bool	Interpolate( double currentTime );
 	virtual void	Simulate();	
 	virtual void	Release();	
 
@@ -143,7 +143,7 @@ public:
  	virtual int	VPhysicsGetObjectList( IPhysicsObject **pList, int listMax );
 
 	// model specific
-	virtual bool SetupBones( matrix3x4_t *pBoneToWorldOut, int nMaxBones, int boneMask, float currentTime );
+	virtual bool SetupBones( matrix3x4_t *pBoneToWorldOut, int nMaxBones, int boneMask, double currentTime );
 	virtual void UpdateIKLocks( float currentTime );
 	virtual void CalculateIKLocks( float currentTime );
 	virtual bool ShouldDraw();
@@ -296,7 +296,7 @@ public:
 	virtual void					Clear( void );
 	void							ClearRagdoll();
 	void							CreateUnragdollInfo( C_BaseAnimating *pRagdoll );
-	bool							ForceSetupBonesAtTime( matrix3x4_t *pBonesOut, float flTime );
+	bool							ForceSetupBonesAtTime( matrix3x4_t *pBonesOut, double flTime );
 	virtual bool					GetRagdollInitBoneArrays( matrix3x4_t *pDeltaBones0, matrix3x4_t *pDeltaBones1, matrix3x4_t *pCurrentBones, float boneDt );
 
 	// For shadows rendering the correct body + sequence...

--- a/game/client/c_baseanimating.h
+++ b/game/client/c_baseanimating.h
@@ -293,8 +293,6 @@ public:
 	bool							InitAsClientRagdoll( const matrix3x4_t *pDeltaBones0, const matrix3x4_t *pDeltaBones1, const matrix3x4_t *pCurrentBonePosition, float boneDt, bool bFixedConstraints=false );
 	void							IgniteRagdoll( C_BaseAnimating *pSource );
 	void							TransferDissolveFrom( C_BaseAnimating *pSource );
-	virtual void					SaveRagdollInfo( int numbones, const matrix3x4_t &cameraTransform, CBoneAccessor &pBoneToWorld );
-	virtual bool					RetrieveRagdollInfo( Vector *pos, Quaternion *q );
 	virtual void					Clear( void );
 	void							ClearRagdoll();
 	void							CreateUnragdollInfo( C_BaseAnimating *pRagdoll );
@@ -503,7 +501,6 @@ protected:
 	float							m_flPlaybackRate;
 
 	// Decomposed ragdoll info
-	bool							m_bStoreRagdollInfo;
 	RagdollInfo_t					*m_pRagdollInfo;
 	Vector							m_vecForce;
 	int								m_nForceBone;
@@ -591,7 +588,6 @@ protected:
 	float							m_flCycle;
 	CInterpolatedVar< float >		m_iv_flCycle;
 	float							m_flOldCycle;
-	bool							m_bNoModelParticles;
 
 private:
 	float							m_flOldModelScale;

--- a/game/client/c_basecombatcharacter.h
+++ b/game/client/c_basecombatcharacter.h
@@ -84,8 +84,8 @@ public:
 	// This is a sort of hack back-door only used by physgun!
 	void SetAmmoCount( int iCount, int iAmmoIndex );
 
-	float				GetNextAttack() const { return m_flNextAttack; }
-	void				SetNextAttack( float flWait ) { m_flNextAttack = flWait; }
+	double				GetNextAttack() const { return m_flNextAttack; }
+	void				SetNextAttack( double flWait ) { m_flNextAttack = flWait; }
 
 	virtual int			BloodColor();
 
@@ -105,7 +105,7 @@ public:
 
 public:
 
-	float			m_flNextAttack;
+	double			m_flNextAttack;
 
 protected:
 

--- a/game/client/c_basedoor.h
+++ b/game/client/c_basedoor.h
@@ -24,9 +24,6 @@ public:
 
 	C_BaseDoor( void );
 	~C_BaseDoor( void );
-
-public:
-	float		m_flWaveHeight;
 };
 
 #endif // C_BASEDOOR_H

--- a/game/client/c_baseentity.h
+++ b/game/client/c_baseentity.h
@@ -452,7 +452,7 @@ public:
 
 // IClientEntity implementation.
 public:
-	virtual bool					SetupBones( matrix3x4_t *pBoneToWorldOut, int nMaxBones, int boneMask, float currentTime );
+	virtual bool					SetupBones( matrix3x4_t *pBoneToWorldOut, int nMaxBones, int boneMask, double currentTime );
 	virtual void					SetupWeights( const matrix3x4_t *pBoneToWorld, int nFlexWeightCount, float *pFlexWeights, float *pFlexDelayedWeights );
 	virtual bool					UsesFlexDelayedWeights() { return false; }
 	virtual void					DoAnimationEvents( void );
@@ -742,7 +742,7 @@ public:
 	virtual void					TextureAnimationWrapped();
 
 	// Set the next think time. Pass in CLIENT_THINK_ALWAYS to have Think() called each frame.
-	virtual void					SetNextClientThink( float nextThinkTime );
+	virtual void					SetNextClientThink( double nextThinkTime );
 
 	// anything that has health can override this...
 	virtual void					SetHealth(int iHealth) {}
@@ -1222,7 +1222,7 @@ protected:
 
 	// Returns INTERPOLATE_STOP or INTERPOLATE_CONTINUE.
 	// bNoMoreChanges is set to 1 if you can call RemoveFromInterpolationList on the entity.
-	int BaseInterpolatePart1( float &currentTime, Vector &oldOrigin, QAngle &oldAngles, Vector &oldVel, int &bNoMoreChanges );
+	int BaseInterpolatePart1( double &currentTime, Vector &oldOrigin, QAngle &oldAngles, Vector &oldVel, int &bNoMoreChanges );
 	void BaseInterpolatePart2( Vector &oldOrigin, QAngle &oldAngles, Vector &oldVel, int nChangeFlags );
 
 
@@ -1341,7 +1341,7 @@ public:
 #endif
 
 	char							m_takedamage;
-	char							m_lifeState;
+	unsigned char					m_lifeState;
 
 	int								m_iHealth;
 

--- a/game/client/c_baseplayer.h
+++ b/game/client/c_baseplayer.h
@@ -310,7 +310,7 @@ public:
 
 	virtual void			SetAnimation( PLAYER_ANIM playerAnim );
 
-	double					GetTimeBase( void ) const;
+	float					GetTimeBase( void ) const;
 	float					GetFinalPredictedTime() const;
 
 	bool					IsInVGuiInputMode() const;

--- a/game/client/c_baseplayer.h
+++ b/game/client/c_baseplayer.h
@@ -310,8 +310,8 @@ public:
 
 	virtual void			SetAnimation( PLAYER_ANIM playerAnim );
 
-	float					GetTimeBase( void ) const;
-	float					GetFinalPredictedTime() const;
+	double					GetTimeBase( void ) const;
+	double					GetFinalPredictedTime() const;
 
 	bool					IsInVGuiInputMode() const;
 	bool					IsInViewModelVGuiInputMode() const;
@@ -379,7 +379,7 @@ public:
 	void					UpdateFogController( void );
 	void					UpdateFogBlend( void );
 
-	float					GetFOVTime( void ){ return m_flFOVTime; }
+	double					GetFOVTime( void ){ return m_flFOVTime; }
 
 	virtual void			OnAchievementAchieved( int iAchievement ) {}
 	
@@ -418,13 +418,10 @@ public:
 	// Player FOV values
 	int						m_iFOV;				// field of view
 	int						m_iFOVStart;		// starting value of the FOV changing over time (client only)
-	float					m_flFOVTime;		// starting time of the FOV zoom
+	double					m_flFOVTime;		// starting time of the FOV zoom
 	int						m_iDefaultFOV;		// default FOV if no other zooms are occurring
 	EHANDLE					m_hZoomOwner;		// This is a pointer to the entity currently controlling the player's zoom
 												// Only this entity can change the zoom state once it has ownership
-
-	// For weapon prediction
-	bool			m_fOnTarget;		//Is the crosshair on a target?
 	
 	char			m_szAnimExtension[32];
 
@@ -585,7 +582,7 @@ protected:
 	virtual bool IsDucked( void ) const { return m_Local.m_bDucked; }
 	virtual bool IsDucking( void ) const { return m_Local.m_bDucking; }
 	virtual float GetFallVelocity( void ) { return m_Local.m_flFallVelocity; }
-	bool ForceSetupBonesAtTimeFakeInterpolation( matrix3x4_t *pBonesOut, float curtimeOffset );
+	bool ForceSetupBonesAtTimeFakeInterpolation( matrix3x4_t *pBonesOut, double curtimeOffset );
 
 	float m_flLaggedMovementValue;
 
@@ -596,8 +593,6 @@ protected:
 	float m_flPredictionErrorTime;
 	
 	Vector m_vecPreviouslyPredictedOrigin; // Used to determine if non-gamemovement game code has teleported, or tweaked the player's origin
-
-	char m_szLastPlaceName[MAX_PLACE_NAME_LENGTH];	// received from the server
 
 	// Texture names and surface data, used by CGameMovement
 	int				m_surfaceProps;
@@ -630,8 +625,6 @@ private:
 	StepSoundCache_t		m_StepSoundCache[ 2 ];
 
 public:
-
-	const char *GetLastKnownPlaceName( void ) const	{ return m_szLastPlaceName; }	// return the last nav place name the player occupied
 
 	float GetLaggedMovementValue( void ){ return m_flLaggedMovementValue;	}
 	bool  ShouldGoSouth( Vector vNPCForward, Vector vNPCRight ); //Such a bad name.

--- a/game/client/c_baseplayer.h
+++ b/game/client/c_baseplayer.h
@@ -310,7 +310,7 @@ public:
 
 	virtual void			SetAnimation( PLAYER_ANIM playerAnim );
 
-	float					GetTimeBase( void ) const;
+	double					GetTimeBase( void ) const;
 	float					GetFinalPredictedTime() const;
 
 	bool					IsInVGuiInputMode() const;

--- a/game/client/c_world.h
+++ b/game/client/c_world.h
@@ -47,7 +47,6 @@ public:
 		MAX_DETAIL_SPRITE_MATERIAL_NAME_LENGTH = 256,
 	};
 
-	float	m_flWaveHeight;
 	Vector	m_WorldMins;
 	Vector	m_WorldMaxs;
 	bool	m_bStartDark;
@@ -55,17 +54,11 @@ public:
 	float	m_flMinOccluderArea;
 	float	m_flMinPropScreenSpaceWidth;
 	float	m_flMaxPropScreenSpaceWidth;
-	bool	m_bColdWorld;
 
 private:
 	void	RegisterSharedActivities( void );
 	char	m_iszDetailSpriteMaterial[MAX_DETAIL_SPRITE_MATERIAL_NAME_LENGTH];
 };
-
-inline float C_World::GetWaveHeight() const
-{
-	return m_flWaveHeight;
-}
 
 inline const char *C_World::GetDetailSpriteMaterial() const
 {

--- a/game/client/client_thinklist.h
+++ b/game/client/client_thinklist.h
@@ -88,9 +88,9 @@ private:
 
 // Internal stuff.
 private:
-	void			SetNextClientThink( ClientThinkHandle_t hThink, float nextTime );
+	void			SetNextClientThink( ClientThinkHandle_t hThink, double nextTime );
 	void			RemoveThinkable( ClientThinkHandle_t hThink );
-	void			PerformThinkFunction( ThinkEntry_t *pEntry, float curtime );
+	void			PerformThinkFunction( ThinkEntry_t *pEntry, double curtime );
 	ThinkEntry_t*	GetThinkEntry( ClientThinkHandle_t hThink );
 	void			CleanUpDeleteList();
 

--- a/game/client/hl2/c_hl2_playerlocaldata.h
+++ b/game/client/hl2/c_hl2_playerlocaldata.h
@@ -36,11 +36,7 @@ public:
 	int		m_iSquadMedicCount;
 	bool	m_fSquadInFollowMode;
 	bool	m_bWeaponLowered;
-	EHANDLE m_hAutoAimTarget;
-	Vector	m_vecAutoAimPoint;
 	bool	m_bDisplayReticle;
-	bool	m_bStickyAutoAim;
-	bool	m_bAutoAimTarget;
 #ifdef HL2_EPISODIC
 	float	m_flFlashBattery;
 	Vector	m_vecLocatorOrigin;

--- a/game/client/hl2mp/c_hl2mp_player.h
+++ b/game/client/hl2mp/c_hl2mp_player.h
@@ -119,8 +119,6 @@ private:
 	int	  m_iSpawnInterpCounter;
 	int	  m_iSpawnInterpCounterCache;
 
-	int	  m_iPlayerSoundType;
-
 	void ReleaseFlashlight( void );
 	Beam_t	*m_pFlashlightBeam;
 

--- a/game/client/interpolatedvar.h
+++ b/game/client/interpolatedvar.h
@@ -97,12 +97,12 @@ public:
 		return s_bAllowExtrapolation;
 	}
 
-	static void SetLastTimeStamp(float timestamp)
+	static void SetLastTimeStamp(double timestamp)
 	{
 		s_flLastTimeStamp = timestamp;
 	}
 	
-	static float GetLastTimeStamp()
+	static double GetLastTimeStamp()
 	{
 		return s_flLastTimeStamp;
 	}
@@ -112,11 +112,11 @@ private:
 
 	CInterpolationContext *m_pNext;
 	bool m_bOldAllowExtrapolation;
-	float m_flOldLastTimeStamp;
+	double m_flOldLastTimeStamp;
 
 	static CInterpolationContext *s_pHead;
 	static bool s_bAllowExtrapolation;
-	static float s_flLastTimeStamp;
+	static double s_flLastTimeStamp;
 };
 
 

--- a/game/client/prediction.h
+++ b/game/client/prediction.h
@@ -115,7 +115,7 @@ private:
 
 	void			RemoveStalePredictedEntities( int last_command_packet );
 	void			RestoreOriginalEntityState( void );
-	void			RunSimulation( int current_command, float curtime, CUserCmd *cmd, C_BasePlayer *localPlayer );
+	void			RunSimulation( int current_command, double curtime, CUserCmd *cmd, C_BasePlayer *localPlayer );
 	void			Untouch( void );
 	void			StorePredictionResults( int predicted_frame );
 	bool			ShouldDumpEntity( C_BaseEntity *ent );

--- a/game/client/prediction.h
+++ b/game/client/prediction.h
@@ -115,7 +115,7 @@ private:
 
 	void			RemoveStalePredictedEntities( int last_command_packet );
 	void			RestoreOriginalEntityState( void );
-	void			RunSimulation( int current_command, double curtime, CUserCmd *cmd, C_BasePlayer *localPlayer );
+	void			RunSimulation( int current_command, float curtime, CUserCmd *cmd, C_BasePlayer *localPlayer );
 	void			Untouch( void );
 	void			StorePredictionResults( int predicted_frame );
 	bool			ShouldDumpEntity( C_BaseEntity *ent );

--- a/game/client/ragdoll.h
+++ b/game/client/ragdoll.h
@@ -86,7 +86,7 @@ public:
 	bool IsValid() { return m_ragdoll.listCount > 0; }
 
 	void ResetRagdollSleepAfterTime( void );
-	float GetLastVPhysicsUpdateTime() const { return m_lastUpdate; }
+	double GetLastVPhysicsUpdateTime() const { return m_lastUpdate; }
 
 private:
 
@@ -97,7 +97,7 @@ private:
 	Vector		m_mins, m_maxs;
 	Vector		m_origin;
 	float		m_radius;
-	float		m_lastUpdate;
+	double		m_lastUpdate;
 	bool		m_allAsleep;
 	Vector		m_vecLastOrigin;
 	float		m_flLastOriginChangeTime;

--- a/game/server/BasePropDoor.h
+++ b/game/server/BasePropDoor.h
@@ -173,12 +173,13 @@ private:
 
 	int		m_nHardwareType;
 	
-	DoorState_t m_eDoorState;	// Holds whether the door is open, closed, opening, or closing.
+	// RaphaelIT7: GMod uses 3 bits for networking!
+	CNetworkVar( DoorState_t, m_eDoorState );	// Holds whether the door is open, closed, opening, or closing.
 
 	locksound_t m_ls;			// The sounds the door plays when being locked, unlocked, etc.
 	EHANDLE		m_hActivator;		
 	
-	bool	m_bLocked;				// True if the door is locked.
+	CNetworkVar( bool, m_bLocked );				// True if the door is locked.
 	EHANDLE	m_hBlocker;				// Entity blocking the door currently
 	bool	m_bFirstBlocked;		// Marker for being the first door (in a group) to be blocked (needed for motion control)
 

--- a/game/server/ServerNetworkProperty.h
+++ b/game/server/ServerNetworkProperty.h
@@ -101,7 +101,6 @@ public:
 	// Recomputes PVS information
 	void RecomputePVSInformation();
 
-public:
 	// Detaches the edict.. should only be called by CBaseNetworkable's destructor.
 	void DetachEdict();
 	CBaseEntity *GetOuter();
@@ -109,7 +108,6 @@ public:
 	// Marks the networkable that it will should transmit
 	void SetTransmit( CCheckTransmitInfo *pInfo );
 
-public:
 	CBaseEntity *m_pOuter;
 	// CBaseTransmitProxy *m_pTransmitProxy;
 	edict_t	*m_pPev;

--- a/game/server/ServerNetworkProperty.h
+++ b/game/server/ServerNetworkProperty.h
@@ -101,7 +101,7 @@ public:
 	// Recomputes PVS information
 	void RecomputePVSInformation();
 
-private:
+public:
 	// Detaches the edict.. should only be called by CBaseNetworkable's destructor.
 	void DetachEdict();
 	CBaseEntity *GetOuter();
@@ -109,7 +109,7 @@ private:
 	// Marks the networkable that it will should transmit
 	void SetTransmit( CCheckTransmitInfo *pInfo );
 
-private:
+public:
 	CBaseEntity *m_pOuter;
 	// CBaseTransmitProxy *m_pTransmitProxy;
 	edict_t	*m_pPev;

--- a/game/server/ai_basenpc.h
+++ b/game/server/ai_basenpc.h
@@ -1541,12 +1541,12 @@ public:
 	virtual bool		UpdateEnemyMemory( CBaseEntity *pEnemy, const Vector &position, CBaseEntity *pInformer = NULL );
 	virtual float		GetReactionDelay( CBaseEntity *pEnemy );
 	
-	void				SetLastAttackTime( float time)	{ m_flLastAttackTime = time; }
+	void				SetLastAttackTime( double time)	{ m_flLastAttackTime = time; }
 
-	float				GetLastAttackTime() const { return m_flLastAttackTime; }
-	float				GetLastDamageTime() const { return m_flLastDamageTime; }
-	float				GetLastPlayerDamageTime() const { return m_flLastPlayerDamageTime; }
-	float				GetLastEnemyTime() const { return m_flLastEnemyTime; }
+	double				GetLastAttackTime() const { return m_flLastAttackTime; }
+	double				GetLastDamageTime() const { return m_flLastDamageTime; }
+	double				GetLastPlayerDamageTime() const { return m_flLastPlayerDamageTime; }
+	double				GetLastEnemyTime() const { return m_flLastEnemyTime; }
 
 	// Set up the shot regulator based on the equipped weapon
 	virtual void		OnChangeActiveWeapon( CBaseCombatWeapon *pOldWeapon, CBaseCombatWeapon *pNewWeapon );
@@ -1576,12 +1576,12 @@ protected:
 	EHANDLE				m_hEnemyOccluder;	// The entity my enemy is hiding behind.
 
 	float				m_flSumDamage;				// How much consecutive damage I've received
-	float				m_flLastDamageTime;			// Last time I received damage
-	float				m_flLastPlayerDamageTime;	// Last time I received damage from the player
-	float				m_flLastSawPlayerTime;		// Last time I saw the player
-	float				m_flLastAttackTime;			// Last time that I attacked my current enemy
-	float				m_flLastEnemyTime;
-	float				m_flNextWeaponSearchTime;	// next time to search for a better weapon
+	double				m_flLastDamageTime;			// Last time I received damage
+	double				m_flLastPlayerDamageTime;	// Last time I received damage from the player
+	double				m_flLastSawPlayerTime;		// Last time I saw the player
+	double				m_flLastAttackTime;			// Last time that I attacked my current enemy
+	double				m_flLastEnemyTime;
+	double				m_flNextWeaponSearchTime;	// next time to search for a better weapon
 	string_t			m_iszPendingWeapon;			// THe NPC should create and equip this weapon.
 	bool				m_bIgnoreUnseenEnemies;
 
@@ -2106,22 +2106,10 @@ public:
 	CNetworkVar( bool,  m_bFadeCorpse );
 	CNetworkVar( bool,  m_bImportanRagdoll );
 
-	CNetworkVar( bool,  m_bSpeedModActive );
-	CNetworkVar( int,   m_iSpeedModRadius );
-	CNetworkVar( int,   m_iSpeedModSpeed );
-	CNetworkVar( float, m_flTimePingEffect );			// Display the pinged effect until this time
-
-	void				InputActivateSpeedModifier( inputdata_t &inputdata ) { m_bSpeedModActive = true; }
-	void				InputDisableSpeedModifier( inputdata_t &inputdata ) { m_bSpeedModActive = false; }
-	void				InputSetSpeedModifierRadius( inputdata_t &inputdata );
-	void				InputSetSpeedModifierSpeed( inputdata_t &inputdata );
-
 	virtual bool		ShouldProbeCollideAgainstEntity( CBaseEntity *pEntity );
 
 	bool				m_bPlayerAvoidState;
 	void				GetPlayerAvoidBounds( Vector *pMins, Vector *pMaxs );
-
-	void				StartPingEffect( void ) { m_flTimePingEffect = gpGlobals->curtime + 2.0f; DispatchUpdateTransmitState(); }
 };
 
 

--- a/game/server/ai_senses.h
+++ b/game/server/ai_senses.h
@@ -91,7 +91,7 @@ public:
 
 	//---------------------------------
 	
-	float			GetTimeLastUpdate( CBaseEntity *pEntity );
+	double			GetTimeLastUpdate( CBaseEntity *pEntity );
 
 	//---------------------------------
 
@@ -123,7 +123,7 @@ private:
 	
 	float			m_LookDist;				// distance npc sees (Default 2048)
 	float			m_LastLookDist;
-	float			m_TimeLastLook;
+	double			m_TimeLastLook;
 	
 	int				m_iAudibleList;				// first index of a linked list of sounds that the npc can hear.
 	
@@ -133,9 +133,9 @@ private:
 	
 	CUtlVector<EHANDLE> *m_SeenArrays[3];
 	
-	float			m_TimeLastLookHighPriority;
-	float			m_TimeLastLookNPCs;
-	float			m_TimeLastLookMisc;
+	double			m_TimeLastLookHighPriority;
+	double			m_TimeLastLookNPCs;
+	double			m_TimeLastLookMisc;
 
 	int				m_iSensingFlags;
 };

--- a/game/server/ai_utils.h
+++ b/game/server/ai_utils.h
@@ -149,7 +149,7 @@ public:
 	bool ShouldShoot() const;
 
 	// When will I shoot next?
-	float NextShotTime() const;
+	double NextShotTime() const;
 
 	// Am I in the middle of a rest period?
 	bool IsInRestInterval() const;
@@ -162,14 +162,14 @@ public:
 	void OnFiredWeapon();
 
 	// Causes us to potentially delay our shooting time
-	void FireNoEarlierThan( float flTime );
+	void FireNoEarlierThan( double flTime );
 
 	// Prevent/Allow shooting
 	void EnableShooting( void );
 	void DisableShooting( void );
 	
 private:
-	float	m_flNextShotTime;
+	double	m_flNextShotTime;
 	bool	m_bInRestInterval;
 	unsigned short	m_nBurstShotsRemaining;
 	unsigned short	m_nMinBurstShots, m_nMaxBurstShots;

--- a/game/server/basecombatcharacter.h
+++ b/game/server/basecombatcharacter.h
@@ -456,6 +456,8 @@ protected:
 	void SetLastHitGroup( int nHitGroup )	{ m_LastHitGroup = nHitGroup; }
 
 public:
+	void* _offsetply1[13];
+
 	CNetworkVar( float, m_flNextAttack );			// cannot attack again until this time
 
 #ifdef GLOWS_ENABLE

--- a/game/server/basecombatcharacter.h
+++ b/game/server/basecombatcharacter.h
@@ -392,8 +392,8 @@ public:
 	// This is a hack to copy the relationship strings used by monstermaker
 	void SetRelationshipString( string_t theString ) { m_RelationshipString = theString; }
 
-	float				GetNextAttack() const { return m_flNextAttack; }
-	void				SetNextAttack( float flWait ) { m_flNextAttack = flWait; }
+	double				GetNextAttack() const { return m_flNextAttack; }
+	void				SetNextAttack( double flWait ) { m_flNextAttack = flWait; }
 
 	bool				m_bForceServerRagdoll;
 
@@ -458,7 +458,7 @@ protected:
 public:
 	void* _offsetply1[13];
 
-	CNetworkVar( float, m_flNextAttack );			// cannot attack again until this time
+	CNetworkVar( double, m_flNextAttack );			// cannot attack again until this time
 
 #ifdef GLOWS_ENABLE
 protected:
@@ -472,7 +472,7 @@ private:
 	void				DestroyGlowEffect( void );
 
 protected:
-	int			m_bloodColor;			// color of blood particless
+	CNetworkVar( int, m_bloodColor );			// color of blood particless (RaphaelIT7: Only 5 bits are used for networking!)
 
 	// -------------------
 	// combat ability data

--- a/game/server/baseentity.h
+++ b/game/server/baseentity.h
@@ -792,7 +792,7 @@ public:
 	CNetworkVar( unsigned char, m_nRenderFX );
 	// was pev->rendermode
 	CNetworkVar( unsigned char, m_nRenderMode );
-	CNetworkVar( short, m_nModelIndex );
+	CNetworkVar( short, m_nModelIndex ); // RaphaelIT7: Only 14 bits are used for networking!
 	
 #ifdef TF_DLL
 	CNetworkArray( int, m_nModelIndexOverrides, MAX_VISION_MODES ); // used to override the base model index on the client if necessary
@@ -1154,7 +1154,7 @@ public:
 	CNetworkVarForDerived( int, m_iMaxHealth ); // CBaseEntity doesn't care about changes to this variable, but there are derived classes that do.
 	CNetworkVarForDerived( int, m_iHealth );
 
-	CNetworkVarForDerived( char, m_lifeState );
+	CNetworkVarForDerived( unsigned char, m_lifeState ); // RaphaelIT7: GMod uses 3 bits for networking
 	CNetworkVarForDerived( char , m_takedamage );
 
 	// Damage filtering

--- a/game/server/basetoggle.h
+++ b/game/server/basetoggle.h
@@ -36,10 +36,11 @@ public:
 
 	float				m_flHeight;
 	EHANDLE				m_hActivator;
-	Vector				m_vecFinalDest;
+	CNetworkVar( Vector, m_vecFinalDest );
 	QAngle				m_vecFinalAngle;
 
-	int					m_movementType;
+	// RaphaelIT7: GMod uses 4 bits for networking!
+	CNetworkVar( int, m_movementType ) ;
 
 	DECLARE_DATADESC();
 

--- a/game/server/colorcorrectionvolume.h
+++ b/game/server/colorcorrectionvolume.h
@@ -1,0 +1,65 @@
+//========= Copyright Valve Corporation, All rights reserved. ============//
+//
+// Purpose: Color correction entity.
+//
+// $NoKeywords: $
+//=============================================================================//
+
+#include <string.h>
+
+#include "cbase.h"
+#include "triggers.h"
+
+// memdbgon must be the last include file in a .cpp file!!!
+#include "tier0/memdbgon.h"
+
+//------------------------------------------------------------------------------
+// FIXME: This really should inherit from something	more lightweight
+//------------------------------------------------------------------------------
+
+
+//------------------------------------------------------------------------------
+// Purpose : Shadow control entity
+//------------------------------------------------------------------------------
+class CColorCorrectionVolume : public CBaseTrigger
+{
+	DECLARE_CLASS( CColorCorrectionVolume, CBaseTrigger );
+public:
+	DECLARE_SERVERCLASS();
+	DECLARE_DATADESC();
+
+	CColorCorrectionVolume();
+
+	void Spawn( void );
+	bool KeyValue( const char *szKeyName, const char *szValue );
+	int  UpdateTransmitState();
+
+	void ThinkFunc();
+
+	virtual bool PassesTriggerFilters(CBaseEntity *pOther);
+	virtual void StartTouch( CBaseEntity *pEntity );
+	virtual void EndTouch( CBaseEntity *pEntity );
+
+	virtual int	ObjectCaps( void ) { return BaseClass::ObjectCaps() & ~FCAP_ACROSS_TRANSITION; }
+	
+	// Inputs
+	void	InputEnable( inputdata_t &inputdata );
+	void	InputDisable( inputdata_t &inputdata );
+
+private:
+
+	bool		m_bEnabled;
+	bool		m_bStartDisabled;
+
+	CNetworkVar( float, m_Weight );
+	CNetworkVar( float, m_MaxWeight ); 
+	CNetworkString( m_lookupFilename, MAX_PATH );
+
+	float		m_LastEnterWeight;
+	float		m_LastEnterTime;
+
+	float		m_LastExitWeight;
+	float		m_LastExitTime;
+
+	float		m_FadeDuration;
+};

--- a/game/server/doors.h
+++ b/game/server/doors.h
@@ -125,8 +125,6 @@ public:
 	string_t	m_NoiseArrivedClosed;		//End sound
 	string_t	m_ChainTarget;		///< Entity name to pass Touch and Use events to
 
-	CNetworkVar( float, m_flWaveHeight );
-
 	// Outputs
 	COutputEvent m_OnBlockedClosing;		// Triggered when the door becomes blocked while closing.
 	COutputEvent m_OnBlockedOpening;		// Triggered when the door becomes blocked while opening.

--- a/game/server/env_projectedtexture.h
+++ b/game/server/env_projectedtexture.h
@@ -37,7 +37,6 @@ public:
 	void InputSetLightOnlyTarget( inputdata_t &inputdata );
 	void InputSetLightWorld( inputdata_t &inputdata );
 	void InputSetEnableShadows( inputdata_t &inputdata );
-//	void InputSetLightColor( inputdata_t &inputdata );
 	void InputSetSpotlightTexture( inputdata_t &inputdata );
 	void InputSetAmbient( inputdata_t &inputdata );
 

--- a/game/server/env_projectedtexture.h
+++ b/game/server/env_projectedtexture.h
@@ -1,0 +1,64 @@
+//========= Copyright Valve Corporation, All rights reserved. ============//
+//
+// Purpose: Entity to control screen overlays on a player
+//
+//=============================================================================
+
+#include "cbase.h"
+#include "shareddefs.h"
+
+// memdbgon must be the last include file in a .cpp file!!!
+#include "tier0/memdbgon.h"
+
+#define ENV_PROJECTEDTEXTURE_STARTON			(1<<0)
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+class CEnvProjectedTexture : public CPointEntity
+{
+	DECLARE_CLASS( CEnvProjectedTexture, CPointEntity );
+public:
+	DECLARE_DATADESC();
+	DECLARE_SERVERCLASS();
+
+	CEnvProjectedTexture();
+	bool KeyValue( const char *szKeyName, const char *szValue );
+
+	// Always transmit to clients
+	virtual int UpdateTransmitState();
+	virtual void Activate( void );
+
+	void InputTurnOn( inputdata_t &inputdata );
+	void InputTurnOff( inputdata_t &inputdata );
+	void InputSetFOV( inputdata_t &inputdata );
+	void InputSetTarget( inputdata_t &inputdata );
+	void InputSetCameraSpace( inputdata_t &inputdata );
+	void InputSetLightOnlyTarget( inputdata_t &inputdata );
+	void InputSetLightWorld( inputdata_t &inputdata );
+	void InputSetEnableShadows( inputdata_t &inputdata );
+//	void InputSetLightColor( inputdata_t &inputdata );
+	void InputSetSpotlightTexture( inputdata_t &inputdata );
+	void InputSetAmbient( inputdata_t &inputdata );
+
+	void InitialThink( void );
+
+	CNetworkHandle( CBaseEntity, m_hTargetEntity );
+
+private:
+
+	CNetworkVar( bool, m_bState );
+	CNetworkVar( float, m_flLightFOV );
+	CNetworkVar( bool, m_bEnableShadows );
+	CNetworkVar( bool, m_bLightOnlyTarget );
+	CNetworkVar( bool, m_bLightWorld );
+	CNetworkVar( bool, m_bCameraSpace );
+	CNetworkVector( m_LinearFloatLightColor );
+	CNetworkVar( float, m_flAmbient );
+	CNetworkString( m_SpotlightTextureName, MAX_PATH );
+	CNetworkVar( int, m_nSpotlightTextureFrame ); // RaphaelIT7: 14 bits are used for networking!
+	CNetworkVar( float, m_flNearZ );
+	CNetworkVar( float, m_flFarZ );
+	CNetworkVar( int, m_nShadowQuality );
+	// Also networks 8 bits for m_iStyle
+};

--- a/game/server/env_screenoverlay.h
+++ b/game/server/env_screenoverlay.h
@@ -1,0 +1,70 @@
+//========= Copyright Valve Corporation, All rights reserved. ============//
+//
+// Purpose: Entity to control screen overlays on a player
+//
+//=============================================================================//
+
+#include "cbase.h"
+#include "shareddefs.h"
+
+// memdbgon must be the last include file in a .cpp file!!!
+#include "tier0/memdbgon.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+class CEnvScreenOverlay : public CPointEntity
+{
+	DECLARE_CLASS( CEnvScreenOverlay, CPointEntity );
+public:
+	DECLARE_DATADESC();
+	DECLARE_SERVERCLASS();
+
+	CEnvScreenOverlay();
+
+	// Always transmit to clients
+	virtual int UpdateTransmitState();
+	virtual void Spawn( void );
+	virtual void Precache( void );
+
+	void	InputStartOverlay( inputdata_t &inputdata );
+	void	InputStopOverlay( inputdata_t &inputdata );
+	void	InputSwitchOverlay( inputdata_t &inputdata );
+
+	void	SetActive( bool bActive ) { m_bIsActive = bActive; }
+	
+protected:
+	CNetworkArray( string_t, m_iszOverlayNames, MAX_SCREEN_OVERLAYS );
+	CNetworkArray( float, m_flOverlayTimes, MAX_SCREEN_OVERLAYS );
+	CNetworkVar( float, m_flStartTime );
+	CNetworkVar( int, m_iDesiredOverlay );
+	CNetworkVar( bool, m_bIsActive );
+};
+
+// ====================================================================================
+//
+//  Screen-space effects
+//
+// ====================================================================================
+
+class CEnvScreenEffect : public CPointEntity
+{
+	DECLARE_CLASS( CEnvScreenEffect, CPointEntity );
+public:
+	DECLARE_DATADESC();
+	DECLARE_SERVERCLASS();
+
+	// We always want to be sent to the client
+	CEnvScreenEffect( void ) { 	AddEFlags( EFL_FORCE_CHECK_TRANSMIT ); }
+	virtual int UpdateTransmitState( void )	{ return SetTransmitState( FL_EDICT_ALWAYS ); }
+	virtual void Spawn( void );
+	virtual void Precache( void );
+
+private:
+
+	void InputStartEffect( inputdata_t &inputdata );
+	void InputStopEffect( inputdata_t &inputdata );
+
+	CNetworkVar( float, m_flDuration );
+	CNetworkVar( int, m_nType ); // RaphaelIT7: Only 12 bits are used for networking!
+};

--- a/game/server/gameinterface.h
+++ b/game/server/gameinterface.h
@@ -61,6 +61,9 @@ public:
 	virtual void			GMOD_ReceiveClientMessage( int unknown, edict_t* pPlayer, bf_read* msg, int unknown2 ) OVERRIDE;
 	virtual void			GMOD_ClientConnected( int userID ) OVERRIDE;
 	virtual void 			GMOD_SentClientStringTables( int userID ) OVERRIDE;
+
+	// Called when a voice packet is received in SV_BroadcastVoiceData
+	virtual void			GMOD_OnReceivedVoicePacket( edict_t *pPlayer ) OVERRIDE;
 };
 
 

--- a/game/server/gmod/luanextbot.h
+++ b/game/server/gmod/luanextbot.h
@@ -1,0 +1,7 @@
+#include "nextbot/nextbot.h"
+
+class LuaNextBot : public NextBotCombatCharacter, CScriptedEntity
+{
+private:
+	CNetworkVar( unsigned char, m_lifeState ); // RaphaelIT7: GMod uses 3 bits for networking
+}

--- a/game/server/gmod/scriptedentity.h
+++ b/game/server/gmod/scriptedentity.h
@@ -1,0 +1,9 @@
+#pragma once
+
+class CScriptedEntity
+{
+private:
+	void* m_Offset[2];
+	CBaseEntity* m_pEntity;
+	CNetworkString( m_ScriptName, 64 );
+}

--- a/game/server/gmod_player.h
+++ b/game/server/gmod_player.h
@@ -53,6 +53,10 @@ public:
 	virtual void GiveAllItems( void );
 	virtual void SetPlayerColor( Vector color );
 	virtual void SetWeaponColor( Vector color );
+
+public:
+	char offset1[1120];
+	CNetworkHandle( CBaseEntity, m_GMOD_Hands );
 };
 
 inline CGMOD_Player *ToCGMOD_Player( CBaseEntity *pEntity )

--- a/game/server/hl2/func_tank.h
+++ b/game/server/hl2/func_tank.h
@@ -140,8 +140,8 @@ protected:
 	virtual Vector WorldBarrelPosition( void );
 	void		UpdateMatrix( void );
 
-	float GetNextAttack() const { return m_flNextAttack; }
-	virtual void SetNextAttack( float flWait ) { m_flNextAttack = flWait; }
+	double GetNextAttack() const { return m_flNextAttack; }
+	virtual void SetNextAttack( double flWait ) { m_flNextAttack = flWait; }
 
 	virtual void Fire( int bulletCount, const Vector &barrelEnd, const Vector &forward, CBaseEntity *pAttacker, bool bIgnoreSpread );
 	void		TankTrace( const Vector &vecStart, const Vector &vecForward, const Vector &vecSpread, trace_t &tr );
@@ -261,7 +261,7 @@ private:
 	// to the man point. If he's en-route, m_bNPCInRoute will be true. 
 	CHandle<CBaseCombatCharacter> m_hController;
 
-	float					m_flNextAttack;
+	double					m_flNextAttack;
 	Vector					m_vecControllerUsePos;
 	
 	float					m_yawCenter;	// "Center" yaw

--- a/game/server/hl2/hl2_playerlocaldata.h
+++ b/game/server/hl2/hl2_playerlocaldata.h
@@ -35,11 +35,7 @@ public:
 	CNetworkVar( int,	m_iSquadMedicCount );
 	CNetworkVar( bool,	m_fSquadInFollowMode );
 	CNetworkVar( bool,	m_bWeaponLowered );
-	CNetworkVar( EHANDLE, m_hAutoAimTarget );
-	CNetworkVar( Vector, m_vecAutoAimPoint );
 	CNetworkVar( bool,	m_bDisplayReticle );
-	CNetworkVar( bool,	m_bStickyAutoAim );
-	CNetworkVar( bool,	m_bAutoAimTarget );
 #ifdef HL2_EPISODIC
 	CNetworkVar( float, m_flFlashBattery );
 	CNetworkVar( Vector, m_vecLocatorOrigin );

--- a/game/server/hl2/npc_houndeye.h
+++ b/game/server/hl2/npc_houndeye.h
@@ -54,7 +54,7 @@ public:
 	bool			IsAnyoneInSquadAttacking( void );
 	void			SpeakSentence( int sentenceType );
 
-	float			m_flNextSecondaryAttack;
+	double			m_flNextSecondaryAttack;
 	bool			m_bLoopClockwise;
 
 	CEnergyWave*	m_pEnergyWave;

--- a/game/server/hl2/npc_stalker.h
+++ b/game/server/hl2/npc_stalker.h
@@ -27,10 +27,10 @@ class CNPC_Stalker : public CAI_BaseStalker
 	DECLARE_CLASS( CNPC_Stalker, CAI_BaseStalker );
 
 public:
-	float			m_flNextAttackSoundTime;
-	float			m_flNextBreatheSoundTime;
-	float			m_flNextScrambleSoundTime;
-	float			m_flNextNPCThink;
+	double			m_flNextAttackSoundTime;
+	double			m_flNextBreatheSoundTime;
+	double			m_flNextScrambleSoundTime;
+	double			m_flNextNPCThink;
 
 	// ------------------------------
 	//	Laser Beam
@@ -38,16 +38,16 @@ public:
 	int					m_eBeamPower;
 	Vector				m_vLaserDir;
 	Vector				m_vLaserTargetPos;
-	float				m_fBeamEndTime;
-	float				m_fBeamRechargeTime;
-	float				m_fNextDamageTime;
-	float				m_nextSmokeTime;
+	double				m_fBeamEndTime;
+	double				m_fBeamRechargeTime;
+	double				m_fNextDamageTime;
+	double				m_nextSmokeTime;
 	float				m_bPlayingHitWall;
 	float				m_bPlayingHitFlesh;
 	CBeam*				m_pBeam;
 	CSprite*			m_pLightGlow;
 	int					m_iPlayerAggression;
-	float				m_flNextScreamTime;
+	double				m_flNextScreamTime;
 
 	void				KillAttackBeam(void);
 	void				DrawAttackBeam(void);

--- a/game/server/hl2/script_intro.h
+++ b/game/server/hl2/script_intro.h
@@ -57,15 +57,15 @@ private:
 	CNetworkVar( QAngle, m_vecCameraViewAngles );
 	CNetworkVar( int, m_iBlendMode );
 	CNetworkVar( int, m_iNextBlendMode );
-	CNetworkVar( float, m_flNextBlendTime );
-	CNetworkVar( float, m_flBlendStartTime );
+	CNetworkVar( double, m_flNextBlendTime );
+	CNetworkVar( double, m_flBlendStartTime );
 	CNetworkVar( int, m_iStartFOV );
 	CNetworkVar( bool, m_bActive );
 
 	// Fov & fov blends
 	CNetworkVar( int, m_iNextFOV );
-	CNetworkVar( float, m_flNextFOVBlendTime );
-	CNetworkVar( float, m_flFOVBlendStartTime );
+	CNetworkVar( double, m_flNextFOVBlendTime );
+	CNetworkVar( double, m_flFOVBlendStartTime );
 	CNetworkVar( int, m_iFOV );
 	CNetworkVar( bool, m_bAlternateFOV );
 

--- a/game/server/hl2mp/hl2mp_player.h
+++ b/game/server/hl2mp/hl2mp_player.h
@@ -103,7 +103,6 @@ public:
 	void  PickDefaultSpawnTeam( void );
 	void  SetupPlayerSoundsByModel( const char *pModelName );
 	const char *GetPlayerModelSoundPrefix( void );
-	int	  GetPlayerModelType( void ) { return m_iPlayerSoundType;	}
 	
 	void  DetonateTripmines( void );
 
@@ -149,7 +148,6 @@ private:
 	int m_iLastWeaponFireUsercmd;
 	int m_iModelType;
 	CNetworkVar( int, m_iSpawnInterpCounter );
-	CNetworkVar( int, m_iPlayerSoundType );
 
 	float m_flNextModelChangeTime;
 	float m_flNextTeamChangeTime;

--- a/game/server/lights.h
+++ b/game/server/lights.h
@@ -38,7 +38,7 @@ public:
 	DECLARE_DATADESC();
 
 private:
-	int		m_iStyle;
+	CNetworkVar( int, m_iStyle ); // RaphaelIT7: Only used by CEnvProjectedTexture
 	int		m_iDefaultStyle;
 	string_t m_iszPattern;
 	char	m_iCurrentFade;

--- a/game/server/nextbot/nextbot.h
+++ b/game/server/nextbot/nextbot.h
@@ -1,0 +1,104 @@
+// NextBotCombatCharacter.h
+// Next generation bot system
+// Author: Michael Booth, April 2005
+//========= Copyright Valve Corporation, All rights reserved. ============//
+
+#ifndef _NEXT_BOT_H_
+#define _NEXT_BOT_H_
+
+#include "NextBotInterface.h"
+#include "NextBotManager.h"
+
+#ifdef TERROR
+#include "player_lagcompensation.h"
+#endif
+
+class NextBotCombatCharacter;
+struct animevent_t;
+
+extern ConVar NextBotStop;
+
+
+//----------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------
+/**
+ * A Next Bot derived from CBaseCombatCharacter
+ */
+class NextBotCombatCharacter : public CBaseCombatCharacter, public INextBot
+{
+public:
+	DECLARE_CLASS( NextBotCombatCharacter, CBaseCombatCharacter );
+	DECLARE_SERVERCLASS();
+	DECLARE_DATADESC();
+	
+	NextBotCombatCharacter( void );
+	virtual ~NextBotCombatCharacter() { }
+
+	virtual void Spawn( void );
+
+	virtual Vector EyePosition( void );
+
+	virtual INextBot *MyNextBotPointer( void ) { return this; }
+
+	// Event hooks into NextBot system ---------------------------------------
+	virtual int OnTakeDamage_Alive( const CTakeDamageInfo &info );
+	virtual int OnTakeDamage_Dying( const CTakeDamageInfo &info );
+	virtual void Event_Killed( const CTakeDamageInfo &info );
+	virtual void HandleAnimEvent( animevent_t *event );
+	virtual void OnNavAreaChanged( CNavArea *enteredArea, CNavArea *leftArea );	// invoked (by UpdateLastKnownArea) when we enter a new nav area (or it is reset to NULL)
+	virtual void Touch( CBaseEntity *other );
+	virtual void SetModel( const char *szModelName );
+	virtual void Ignite( float flFlameLifetime, bool bNPCOnly = true, float flSize = 0.0f, bool bCalledByLevelDesigner = false );
+	virtual void Ignite( float flFlameLifetime, CBaseEntity *pAttacker );
+	//------------------------------------------------------------------------
+
+	virtual bool IsUseableEntity( CBaseEntity *entity, unsigned int requiredCaps = 0 );
+	void UseEntity( CBaseEntity *entity, USE_TYPE useType = USE_TOGGLE );
+
+	// Implement this if you use MOVETYPE_CUSTOM
+	virtual void PerformCustomPhysics( Vector *pNewPosition, Vector *pNewVelocity, QAngle *pNewAngles, QAngle *pNewAngVelocity );
+
+	virtual bool BecomeRagdoll( const CTakeDamageInfo &info, const Vector &forceVector );
+	
+	// hook to INextBot update
+	void DoThink( void );
+
+	// expose to public
+	int	GetLastHitGroup( void ) const;								// where on our body were we injured last
+
+	virtual bool IsAreaTraversable( const CNavArea *area ) const;							// return true if we can use the given area 
+
+	virtual CBaseCombatCharacter *GetLastAttacker( void ) const;	// return the character who last attacked me
+
+	// begin INextBot public interface ----------------------------------------------------------------
+	virtual NextBotCombatCharacter *GetEntity( void ) const			{ return const_cast< NextBotCombatCharacter * >( this ); }
+	virtual NextBotCombatCharacter *GetNextBotCombatCharacter( void ) const	{ return const_cast< NextBotCombatCharacter * >( this ); }
+	
+
+private:
+	EHANDLE m_lastAttacker;
+	
+	bool m_didModelChange;
+};
+
+
+inline CBaseCombatCharacter *NextBotCombatCharacter::GetLastAttacker( void ) const
+{
+	return ( m_lastAttacker.Get() == NULL ) ? NULL : m_lastAttacker->MyCombatCharacterPointer();
+}
+
+inline int NextBotCombatCharacter::GetLastHitGroup( void ) const
+{
+	return LastHitGroup();
+}
+
+//-----------------------------------------------------------------------------------------------------
+class NextBotDestroyer
+{
+public:
+	NextBotDestroyer( int team );
+	bool operator() ( INextBot *bot );
+	int m_team;			// the team to delete bots from, or TEAM_ANY for any team
+};
+
+#endif // _NEXT_BOT_H_

--- a/game/server/particle_fire.h
+++ b/game/server/particle_fire.h
@@ -25,8 +25,8 @@ public:
 					DECLARE_SERVERCLASS();
 
 	// The client shoots a ray out and starts creating fire where it hits.
-	CNetworkVector( m_vOrigin );
-	CNetworkVector( m_vDirection );
+	Vector m_vOrigin;
+	Vector m_vDirection;
 };
 
 

--- a/game/server/player.h
+++ b/game/server/player.h
@@ -603,8 +603,6 @@ public:
 
 	virtual void DoMuzzleFlash();
 
-	const char *GetLastKnownPlaceName( void ) const	{ return m_szLastPlaceName; }	// return the last nav place name the player occupied
-
 	virtual void			CheckChatText( char *p, int bufsize ) {}
 
 	virtual void			CreateRagdollEntity( void ) { return; }
@@ -668,7 +666,6 @@ public:
 	inline void SetActivity( Activity eActivity ) { m_Activity = eActivity; }
 	bool	IsPlayerLockedInPlace() const { return m_iPlayerLocked != 0; }
 	bool	IsObserver() const		{ return (m_afPhysicsFlags & PFLAG_OBSERVER) != 0; }
-	bool	IsOnTarget() const		{ return m_fOnTarget; }
 	float	MuzzleFlashTime() const { return m_flFlashTime; }
 	float	PlayerDrownTime() const	{ return m_AirFinished; }
 
@@ -722,8 +719,8 @@ public:
 	void	ForceOrigin( const Vector &vecOrigin );
 
 	// Bot accessors...
-	void	SetTimeBase( float flTimeBase );
-	float	GetTimeBase() const;
+	void	SetTimeBase( double flTimeBase );
+	double	GetTimeBase() const;
 	void	SetLastUserCommand( const CUserCmd &cmd );
 	const CUserCmd *GetLastUserCommand( void );
 	
@@ -870,8 +867,6 @@ public:
 	int						m_afButtonDisabled;	// A mask of input flags that are cleared automatically
 	int						m_afButtonForced;	// These are forced onto the player's inputs
 
-	CNetworkVar( bool, m_fOnTarget );		//Is the crosshair on a target?
-
 	char					_offsetply3[5];
 	char					m_szAnimExtension[32];
 
@@ -886,7 +881,7 @@ public:
 
 	void		SetPreviouslyPredictedOrigin( const Vector &vecAbsOrigin );
 	const Vector &GetPreviouslyPredictedOrigin() const;
-	float		GetFOVTime( void ){ return m_flFOVTime; }
+	double		GetFOVTime( void ){ return m_flFOVTime; }
 
 	void		AdjustDrownDmg( int nAmount );
 
@@ -949,10 +944,13 @@ protected:
 	float					m_flDeathAnimTime;	// the time at which the player finished their death anim (used in PlayerDeathThink() and ShouldTransmit())
 
 	CNetworkVar( int, m_iObserverMode );	// if in spectator mode != 0
+	
+	// RaphaelIT7: GMod uses 16 bits for networking
 	CNetworkVar( int,	m_iFOV );			// field of view
 	CNetworkVar( int,	m_iDefaultFOV );	// default field of view
 	CNetworkVar( int,	m_iFOVStart );		// What our FOV started at
-	CNetworkVar( float,	m_flFOVTime );		// Time our FOV change started
+	
+	CNetworkVar( double,	m_flFOVTime );		// Time our FOV change started
 	
 	int						m_iObserverLastMode; // last used observer mode
 	CNetworkHandle( CBaseEntity, m_hObserverTarget );	// entity handle to m_iObserverTarget
@@ -1168,8 +1166,6 @@ protected:
 	Vector m_vecPreviouslyPredictedOrigin; // Used to determine if non-gamemovement game code has teleported, or tweaked the player's origin
 	int		m_nBodyPitchPoseParam;
 
-	CNetworkString( m_szLastPlaceName, MAX_PLACE_NAME_LENGTH );
-
 	char m_szNetworkIDString[MAX_NETWORKID_LENGTH];
 	CPlayerInfo m_PlayerInfo;
 
@@ -1307,7 +1303,7 @@ inline CBaseEntity *CBasePlayer::GetUseEntity()
 }
 
 // Bot accessors...
-inline void CBasePlayer::SetTimeBase( float flTimeBase ) 
+inline void CBasePlayer::SetTimeBase( double flTimeBase ) 
 { 
 	m_nTickBase = TIME_TO_TICKS( flTimeBase ); 
 }

--- a/game/server/player.h
+++ b/game/server/player.h
@@ -722,8 +722,8 @@ public:
 	void	ForceOrigin( const Vector &vecOrigin );
 
 	// Bot accessors...
-	void	SetTimeBase( double flTimeBase );
-	double	GetTimeBase() const;
+	void	SetTimeBase( float flTimeBase );
+	float	GetTimeBase() const;
 	void	SetLastUserCommand( const CUserCmd &cmd );
 	const CUserCmd *GetLastUserCommand( void );
 	
@@ -1307,7 +1307,7 @@ inline CBaseEntity *CBasePlayer::GetUseEntity()
 }
 
 // Bot accessors...
-inline void CBasePlayer::SetTimeBase( double flTimeBase ) 
+inline void CBasePlayer::SetTimeBase( float flTimeBase ) 
 { 
 	m_nTickBase = TIME_TO_TICKS( flTimeBase ); 
 }

--- a/game/server/player.h
+++ b/game/server/player.h
@@ -722,8 +722,8 @@ public:
 	void	ForceOrigin( const Vector &vecOrigin );
 
 	// Bot accessors...
-	void	SetTimeBase( float flTimeBase );
-	float	GetTimeBase() const;
+	void	SetTimeBase( double flTimeBase );
+	double	GetTimeBase() const;
 	void	SetLastUserCommand( const CUserCmd &cmd );
 	const CUserCmd *GetLastUserCommand( void );
 	
@@ -1307,7 +1307,7 @@ inline CBaseEntity *CBasePlayer::GetUseEntity()
 }
 
 // Bot accessors...
-inline void CBasePlayer::SetTimeBase( float flTimeBase ) 
+inline void CBasePlayer::SetTimeBase( double flTimeBase ) 
 { 
 	m_nTickBase = TIME_TO_TICKS( flTimeBase ); 
 }

--- a/game/server/player.h
+++ b/game/server/player.h
@@ -827,7 +827,6 @@ public:
 
 	// Used by gamemovement to check if the entity is stuck.
 	int m_StuckLast;
-	void* _offsetply1[14];
 	// FIXME: Make these protected or private!
 
 	// This player's data that should only be replicated to 

--- a/game/server/sendproxy.h
+++ b/game/server/sendproxy.h
@@ -36,6 +36,11 @@ SendProp SendPropTime(
 	int offset,
 	int sizeofVar=SIZEOF_IGNORE );
 
+SendProp SendPropTime64(
+	const char *pVarName,
+	int offset,
+	int sizeofVar=SIZEOF_IGNORE );
+
 #if !defined( NO_ENTITY_PREDICTION )
 SendProp SendPropPredictableId(
 	const char *pVarName,

--- a/game/server/te_bloodsprite.h
+++ b/game/server/te_bloodsprite.h
@@ -1,0 +1,40 @@
+//========= Copyright Valve Corporation, All rights reserved. ============//
+//
+// Purpose: 
+//
+// $Workfile:     $
+// $Date:         $
+//
+//-----------------------------------------------------------------------------
+// $Log: $
+//
+// $NoKeywords: $
+//=============================================================================//
+#pragma once
+
+#include "basetempentity.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: Display's a blood sprite
+//-----------------------------------------------------------------------------
+class CTEBloodSprite : public CBaseTempEntity
+{
+public:
+	DECLARE_CLASS( CTEBloodSprite, CBaseTempEntity );
+
+					CTEBloodSprite( const char *name );
+	virtual			~CTEBloodSprite( void );
+
+	virtual void	Test( const Vector& current_origin, const QAngle& current_angles );
+
+	DECLARE_SERVERCLASS();
+
+public:
+	CNetworkVector( m_vecOrigin );
+	CNetworkVector( m_vecDirection );
+	CNetworkVar( int, r );
+	CNetworkVar( int, g );
+	CNetworkVar( int, b );
+	CNetworkVar( int, a );
+	CNetworkVar( int, m_nSize );
+};

--- a/game/server/te_explosion.h
+++ b/game/server/te_explosion.h
@@ -1,0 +1,37 @@
+//========= Copyright Valve Corporation, All rights reserved. ============//
+//
+// Purpose: 
+//
+// $Workfile:     $
+// $Date:         $
+//
+//-----------------------------------------------------------------------------
+// $Log: $
+//
+// $NoKeywords: $
+//=============================================================================//
+#pragma once
+
+#include "te_particlesystem.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: Dispatches explosion tempentity
+//-----------------------------------------------------------------------------
+class CTEExplosion : public CTEParticleSystem
+{
+public:
+	DECLARE_CLASS( CTEExplosion, CTEParticleSystem );
+	DECLARE_SERVERCLASS();
+
+					CTEExplosion( const char *name );
+	virtual			~CTEExplosion( void );
+
+	virtual void	Test( const Vector& current_origin, const QAngle& current_angles );
+	
+
+public:
+	CNetworkVar( float, m_fScale );
+	CNetworkVar( int, m_nFlags );
+	CNetworkVar( int, m_nRadius );
+	CNetworkVar( int, m_nMagnitude );
+};

--- a/game/server/te_footprintdecal.h
+++ b/game/server/te_footprintdecal.h
@@ -1,0 +1,38 @@
+//========= Copyright Valve Corporation, All rights reserved. ============//
+//
+// Purpose: 
+//
+// $Workfile:     $
+// $Date:         $
+//
+//-----------------------------------------------------------------------------
+// $Log: $
+//
+// $NoKeywords: $
+//=============================================================================//
+#pragma once
+
+#include "basetempentity.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: Dispatches footprint decal tempentity
+//-----------------------------------------------------------------------------
+
+#define FOOTPRINT_DECAY_TIME 3.0f
+
+class CTEFootprintDecal : public CBaseTempEntity
+{
+public:
+	DECLARE_CLASS( CTEFootprintDecal, CBaseTempEntity );
+
+					CTEFootprintDecal( const char *name );
+	virtual			~CTEFootprintDecal( void );
+
+	DECLARE_SERVERCLASS();
+
+public:
+	CNetworkVector( m_vecOrigin );
+	CNetworkVector( m_vecDirection );											
+	CNetworkVar( int, m_nEntity );
+	CNetworkVar( int, m_nIndex );
+};

--- a/game/server/te_largefunnel.h
+++ b/game/server/te_largefunnel.h
@@ -1,0 +1,36 @@
+//========= Copyright Valve Corporation, All rights reserved. ============//
+//
+// Purpose: 
+//
+// $Workfile:     $
+// $Date:         $
+//
+//-----------------------------------------------------------------------------
+// $Log: $
+//
+// $NoKeywords: $
+//=============================================================================//
+#pragma once
+
+#include "te_particlesystem.h"
+
+// dimhotepus: short -> int.
+extern int	g_sModelIndexSmoke;			// (in combatweapon.cpp) holds the index for the smoke cloud
+
+//-----------------------------------------------------------------------------
+// Purpose: Dispatches smoke tempentity
+//-----------------------------------------------------------------------------
+class CTELargeFunnel : public CTEParticleSystem
+{
+public:
+	DECLARE_CLASS( CTELargeFunnel, CTEParticleSystem );
+	DECLARE_SERVERCLASS();
+
+					CTELargeFunnel( const char *name );
+	virtual			~CTELargeFunnel( void );
+
+	virtual void	Test( const Vector& current_origin, const QAngle& current_angles );
+	
+public:
+	CNetworkVar( int, m_nReversed );
+};

--- a/game/server/util.h
+++ b/game/server/util.h
@@ -345,7 +345,6 @@ void		UTIL_ShowMessage		( const char *pString, CBasePlayer *pPlayer );
 void		UTIL_ShowMessageAll		( const char *pString );
 void		UTIL_ScreenFadeAll		( const color32 &color, float fadeTime, float holdTime, int flags );
 void		UTIL_ScreenFade			( CBaseEntity *pEntity, const color32 &color, float fadeTime, float fadeHold, int flags );
-void		UTIL_MuzzleFlash		( const Vector &origin, const QAngle &angles, int scale, int type );
 Vector		UTIL_PointOnLineNearestPoint(const Vector& vStartPos, const Vector& vEndPos, const Vector& vPoint, bool clampEnds = false );
 
 int			UTIL_EntityInSolid( CBaseEntity *ent );

--- a/game/server/vehicle_base.h
+++ b/game/server/vehicle_base.h
@@ -265,9 +265,6 @@ public:
 	CNetworkVar( bool, m_bUnableToFire );
 	CNetworkVar( bool, m_bHasGun );
 
-	CNetworkVar( bool, m_nScannerDisabledWeapons );
-	CNetworkVar( bool, m_nScannerDisabledVehicle );
-
 	// NPC Driver
 	CHandle<CNPC_VehicleDriver>	 m_hNPCDriver;
 	EHANDLE						 m_hKeepUpright;
@@ -293,7 +290,7 @@ public:
 protected:
 	// Entering / Exiting
 	bool		m_bEngineLocked;	// Mapmaker override on whether the vehicle's allowed to be turned on/off
-	bool		m_bLocked;
+	CNetworkVar( bool, m_bLocked );
 	float		m_flMinimumSpeedToEnterExit;
 	CNetworkVar( bool, m_bEnterAnimOn );
 	CNetworkVar( bool, m_bExitAnimOn );

--- a/game/server/world.h
+++ b/game/server/world.h
@@ -39,25 +39,17 @@ public:
 		VectorCopy( m_WorldMaxs, vecMaxs );
 	}
 
-	inline float GetWaveHeight() const
-	{
-		return (float)m_flWaveHeight;
-	}
-
 	bool GetDisplayTitle() const;
 	bool GetStartDark() const;
 
 	void SetDisplayTitle( bool display );
 	void SetStartDark( bool startdark );
 
-	bool IsColdWorld( void );
-
 private:
 	DECLARE_DATADESC();
 
 	string_t m_iszChapterTitle;
 
-	CNetworkVar( float, m_flWaveHeight );
 	CNetworkVector( m_WorldMins );
 	CNetworkVector( m_WorldMaxs );
 	CNetworkVar( float, m_flMaxOccludeeArea );
@@ -68,7 +60,6 @@ private:
 
 	// start flags
 	CNetworkVar( bool, m_bStartDark );
-	CNetworkVar( bool, m_bColdWorld );
 	bool m_bDisplayTitle;
 };
 

--- a/game/shared/basecombatweapon_shared.h
+++ b/game/shared/basecombatweapon_shared.h
@@ -584,9 +584,9 @@ public:
 	CNetworkVar( int, m_nViewModelIndex );
 
 	// Weapon firing
-	CNetworkVar( float, m_flNextPrimaryAttack );						// soonest time ItemPostFrame will call PrimaryAttack
-	CNetworkVar( float, m_flNextSecondaryAttack );					// soonest time ItemPostFrame will call SecondaryAttack
-	CNetworkVar( float, m_flTimeWeaponIdle );							// soonest time ItemPostFrame will call WeaponIdle
+	CNetworkVar( double, m_flNextPrimaryAttack );						// soonest time ItemPostFrame will call PrimaryAttack
+	CNetworkVar( double, m_flNextSecondaryAttack );					// soonest time ItemPostFrame will call SecondaryAttack
+	CNetworkVar( double, m_flTimeWeaponIdle );							// soonest time ItemPostFrame will call WeaponIdle
 	// Weapon state
 	bool					m_bInReload;			// Are we in the middle of a reload;
 	bool					m_bFireOnEmpty;			// True when the gun is empty and the player is still holding down the attack key(s)
@@ -623,7 +623,7 @@ public:
 	int						WeaponState() const { return m_iState; }
 
 	// Weapon data
-	CNetworkVar( int, m_iState );				// See WEAPON_* definition
+	CNetworkVar( int, m_iState );				// See WEAPON_* definition (RaphaelIT7: Only 4 bits are used for networking!)
 	string_t				m_iszName;				// Classname of this weapon.
 	CNetworkVar( int, m_iPrimaryAmmoType );		// "primary" ammo index into the ammo info array 
 	CNetworkVar( int, m_iSecondaryAmmoType );	// "secondary" ammo index into the ammo info array

--- a/game/shared/basegrenade_shared.h
+++ b/game/shared/basegrenade_shared.h
@@ -120,9 +120,9 @@ public:
 	bool				m_bHasWarnedAI;				// whether or not this grenade has issued its DANGER sound to the world sound list yet.
 	CNetworkVar( bool, m_bIsLive );					// Is this grenade live, or can it be picked up?
 	CNetworkVar( float, m_DmgRadius );				// How far do I do damage?
-	CNetworkVar( float, m_flNextAttack );
-	float				m_flDetonateTime;			// Time at which to detonate.
-	float				m_flWarnAITime;				// Time at which to warn the AI
+	CNetworkVar( double, m_flNextAttack );
+	double				m_flDetonateTime;			// Time at which to detonate.
+	double				m_flWarnAITime;				// Time at which to warn the AI
 
 protected:
 

--- a/game/shared/baseviewmodel_shared.h
+++ b/game/shared/baseviewmodel_shared.h
@@ -183,7 +183,7 @@ private:
 	CNetworkHandle( CBaseEntity, m_hOwner );				// Player or AI carrying this weapon
 
 	// soonest time Update will call WeaponIdle
-	float					m_flTimeWeaponIdle;							
+	double					m_flTimeWeaponIdle;							
 
 	Activity				m_Activity;
 

--- a/game/shared/hl2/env_headcrabcanister_shared.h
+++ b/game/shared/hl2/env_headcrabcanister_shared.h
@@ -58,7 +58,7 @@ public:
 
 	CNetworkVar( float,	m_flFlightTime );
 	CNetworkVar( float,	m_flFlightSpeed );
-	CNetworkVar( float,	m_flLaunchTime );
+	CNetworkVar( double,	m_flLaunchTime );
 
 	CNetworkVar( float, m_flInitialZSpeed );
 	CNetworkVar( float, m_flZAcceleration );

--- a/game/shared/hl2mp/weapon_hl2mpbase_machinegun.h
+++ b/game/shared/hl2mp/weapon_hl2mpbase_machinegun.h
@@ -50,7 +50,8 @@ private:
 
 protected:
 
-	int	m_nShotsFired;	// Number of consecutive shots fired
+	// RaphaelIT7: Only 16 bits are used for networking!
+	CNetworkVar( int, m_nShotsFired );	// Number of consecutive shots fired
 
 	float	m_flNextSoundTime;	// real-time clock of when to make next sound
 };

--- a/game/shared/physics_shared.h
+++ b/game/shared/physics_shared.h
@@ -12,7 +12,7 @@
 
 class IPhysics;
 class IPhysicsEnvironment;
-class IPhysicsSurfaceProps;
+class IPhysicsSurfacePropsInternal;
 class IPhysicsCollision;
 class IPhysicsObject;
 class IPhysicsObjectPairHash;
@@ -26,7 +26,7 @@ extern IPhysicsEnvironment	*physenv;
 #ifdef PORTAL
 extern IPhysicsEnvironment	*physenv_main;
 #endif
-extern IPhysicsSurfaceProps *physprops;
+extern IPhysicsSurfacePropsInternal *physprops;
 extern IPhysicsObjectPairHash *g_EntityCollisionHash;
 
 extern const objectparams_t g_PhysDefaultObjectParams;

--- a/game/shared/saverestore.h
+++ b/game/shared/saverestore.h
@@ -105,6 +105,7 @@ public:
 	//
 	
 	void			WriteTime( const char *pname, const float *value, int count = 1 );	           // Save a float (timevalue)
+	void			WriteTime64( const char *pname, const double *value, int count = 1 );	       // Save a double (timevalue)
 	void			WriteTick( const char *pname, const int *value, int count = 1 );	           // Save a int (timevalue)
 	void			WritePositionVector( const char *pname, const Vector &value );		           // Offset for landmark if necessary
 	void			WritePositionVector( const char *pname, const Vector *value, int count = 1 );  // array of pos vectors
@@ -245,6 +246,7 @@ public:
 	//
 	
 	int				ReadTime( float *pValue, int count = 1, int nBytesAvailable = 0);
+	int				ReadTime64( double *pValue, int count = 1, int nBytesAvailable = 0);
 	int				ReadTick( int *pValue, int count = 1, int nBytesAvailable = 0);
 	int				ReadPositionVector( Vector *pValue );
 	int				ReadPositionVector( Vector *pValue, int count = 1, int nBytesAvailable = 0);

--- a/game/shared/shareddefs.h
+++ b/game/shared/shareddefs.h
@@ -14,7 +14,7 @@
 #define TICK_INTERVAL			(gpGlobals->interval_per_tick)
 
 
-#define TIME_TO_TICKS( dt )		( (int)( 0.5f + (float)(dt) / TICK_INTERVAL ) )
+#define TIME_TO_TICKS( dt )		( (int)( 0.5f + (double)(dt) / TICK_INTERVAL ) )
 #define TICKS_TO_TIME( t )		( TICK_INTERVAL *( t ) )
 #define ROUND_TO_TICKS( t )		( TICK_INTERVAL * TIME_TO_TICKS( t ) )
 #define TICK_NEVER_THINK		(-1)

--- a/game/shared/shareddefs.h
+++ b/game/shared/shareddefs.h
@@ -14,7 +14,7 @@
 #define TICK_INTERVAL			(gpGlobals->interval_per_tick)
 
 
-#define TIME_TO_TICKS( dt )		( (int)( 0.5f + (double)(dt) / TICK_INTERVAL ) )
+#define TIME_TO_TICKS( dt )		( (int)( 0.5f + (float)(dt) / TICK_INTERVAL ) )
 #define TICKS_TO_TIME( t )		( TICK_INTERVAL *( t ) )
 #define ROUND_TO_TICKS( t )		( TICK_INTERVAL * TIME_TO_TICKS( t ) )
 #define TICK_NEVER_THINK		(-1)

--- a/game/shared/simtimer.h
+++ b/game/shared/simtimer.h
@@ -72,7 +72,7 @@ public:
 	DECLARE_SIMPLE_DATADESC();
 	
 protected:
-	float m_next;
+	double m_next;
 };
 
 //-----------------------------------------------------------------------------
@@ -340,7 +340,7 @@ public:
 	}
 
 private:
-	float m_lastTime;
+	double m_lastTime;
 };
 
 //-----------------------------------------------------------------------------

--- a/mathlib/imagequant.cpp
+++ b/mathlib/imagequant.cpp
@@ -57,7 +57,7 @@ void ColorQuantize(uint8 const *Image,
 	{
 		struct QuantizedValue *v=FindQNode(q,p);
 		if (v)
-			for(int c=0;c<3;c++)
+			for(c=0;c<3;c++)
 				out_palette[p*3+c]=v->Mean[c];
 	}
 	memset(Error,0,sizeof(Error));

--- a/mathlib/polyhedron.cpp
+++ b/mathlib/polyhedron.cpp
@@ -1015,7 +1015,7 @@ CPolyhedron *ClipLinkedGeometry( GeneratePolyhedronFromPlanes_UnorderedPolygonLL
 
 			//Scan for onplane points connected to only other onplane/dead points, these points get downgraded to dead status.
 			{
-				GeneratePolyhedronFromPlanes_UnorderedPointLL *pActivePointWalk = pAllPoints;
+				pActivePointWalk = pAllPoints;
 				do
 				{
 					if( pActivePointWalk->pPoint->planarity == POINT_ONPLANE )

--- a/mathlib/quantize.cpp
+++ b/mathlib/quantize.cpp
@@ -197,8 +197,8 @@ static void UpdateStats(struct QuantizedValue *v)
 		N+=s->Count;
 		for(j=0;j<current_ndims;j++)
 		{
-			uint8 v=s->Value[j];
-			Means[j]+=v*s->Count;
+			uint8 v2=s->Value[j];
+			Means[j]+=v2*s->Count;
 		}
 	}
 	for(j=0;j<current_ndims;j++)
@@ -315,7 +315,7 @@ static void SubdivideNode(struct QuantizedValue *n, int whichdim)
 		// extrema instead. LocalMean[i][0] will be the point with the lowest
 		// value on the dimension and LocalMean[i][1] the one with the lowest
 		// value.
-		for(int i=0;i<current_ndims;i++)
+		for(i=0;i<current_ndims;i++)
 		{
 			LocalMean[i][0]=minS->Value[i];
 			LocalMean[i][1]=maxS->Value[i];

--- a/public/GarrysMod/CGMODVariant.h
+++ b/public/GarrysMod/CGMODVariant.h
@@ -26,7 +26,7 @@ class CBaseHandle;
 struct CGMODVariant // NOTE: It doesn't seem work perfectly with GMOD(I hate m_Ent)
 {
 	CGMODVariant() { memset(this, 0, sizeof(CGMODVariant)); }
-	unsigned char type; // Used by Push_GMODVariant to determen which function to use to push it.
+	unsigned char type = 0; // Used by Push_GMODVariant to determine which function to use to push it.
 	union {
 		struct {
 			int m_Length;

--- a/public/GarrysMod/CGMODVariant.h
+++ b/public/GarrysMod/CGMODVariant.h
@@ -25,7 +25,8 @@
 class CBaseHandle;
 struct CGMODVariant // NOTE: It doesn't seem work perfectly with GMOD(I hate m_Ent)
 {
-	unsigned char type = 0; // Used by Push_GMODVariant to determen which function to use to push it.
+	CGMODVariant() { memset(this, 0, sizeof(CGMODVariant)); }
+	unsigned char type; // Used by Push_GMODVariant to determen which function to use to push it.
 	union {
 		struct {
 			int m_Length;

--- a/public/GarrysMod/IGarrysMod.h
+++ b/public/GarrysMod/IGarrysMod.h
@@ -6,9 +6,6 @@ abstract_class IGarrysMod : public IGameEventListener2
 {
 public:
 	virtual void MenuThink() = 0;
-	virtual void MD5String( char* out, const char*, const char*, const char* ) = 0;
-	virtual void PlaySound( const char* sound ) = 0;
-	virtual const char* GetMapName() = 0;
 	virtual void RunConsoleCommand( const char* cmd ) = 0;
 	virtual void StartVideoScale( int, int ) = 0;
 	virtual void EndVideoScale( int, int ) = 0;

--- a/public/GarrysMod/IGet.h
+++ b/public/GarrysMod/IGet.h
@@ -69,7 +69,6 @@ public:
 	virtual IGMod_Audio* Audio() = 0;
 	virtual const char* VersionTimeStr() = 0;
 	virtual IAnalytics Analytics() = 0;
-	virtual const char* BuildName() = 0;
 	virtual void UpdateRichPresense( const char* status ) = 0;
 	virtual void ResetRichPresense() = 0;
 	virtual void FilterText(const char*, char*, int, ETextFilteringContext, CSteamID) = 0;

--- a/public/GarrysMod/IGet.h
+++ b/public/GarrysMod/IGet.h
@@ -45,8 +45,8 @@ public:
 	virtual IResources* Resources() = 0;
 	virtual IIntroScreen* IntroScreen() = 0;
 	virtual IMaterialSystem* Materials() = 0;
-	virtual IGMHTML* HTML() = 0;
 	virtual IServerAddons* ServerAddons() = 0;
+	virtual IGMHTML* HTML() = 0;
 	virtual ISteamHTTP* SteamHTTP() = 0;
 	virtual ISteamRemoteStorage* SteamRemoteStorage() = 0;
 	virtual ISteamUtils* SteamUtils() = 0;
@@ -71,5 +71,6 @@ public:
 	virtual IAnalytics Analytics() = 0;
 	virtual void UpdateRichPresense( const char* status ) = 0;
 	virtual void ResetRichPresense() = 0;
+	virtual const char* BaseDir() = 0; // ToDo: Check if this is dedicated server only
 	virtual void FilterText(const char*, char*, int, ETextFilteringContext, CSteamID) = 0;
 };

--- a/public/bone_setup.cpp
+++ b/public/bone_setup.cpp
@@ -2307,12 +2307,12 @@ void IBoneSetup::InitPose( Vector pos[], Quaternion q[] )
 	::InitPose( m_pBoneSetup->m_pStudioHdr, pos, q, m_pBoneSetup->m_boneMask );
 }
 
-void IBoneSetup::AccumulatePose( Vector pos[], Quaternion q[], int sequence, float cycle, float flWeight, float flTime, CIKContext *pIKContext )
+void IBoneSetup::AccumulatePose( Vector pos[], Quaternion q[], int sequence, float cycle, float flWeight, double flTime, CIKContext *pIKContext )
 {
 	m_pBoneSetup->AccumulatePose( pos, q, sequence, cycle, flWeight, flTime, pIKContext );
 }
 
-void IBoneSetup::CalcAutoplaySequences(	Vector pos[], Quaternion q[], float flRealTime, CIKContext *pIKContext )
+void IBoneSetup::CalcAutoplaySequences(	Vector pos[], Quaternion q[], double flRealTime, CIKContext *pIKContext )
 {
 	m_pBoneSetup->CalcAutoplaySequences( pos, q, flRealTime, pIKContext );
 }
@@ -2396,7 +2396,7 @@ void CBoneSetup::AccumulatePose(
 	int sequence, 
 	float cycle,
 	float flWeight,
-	float flTime,
+	double flTime,
 	CIKContext *pIKContext
 	)
 {
@@ -4460,7 +4460,7 @@ void CIKContext::SolveLock(
 void CBoneSetup::CalcAutoplaySequences(
    Vector pos[], 
    Quaternion q[], 
-   float flRealTime,
+   double flRealTime,
    CIKContext *pIKContext
    )
 {

--- a/public/bone_setup.h
+++ b/public/bone_setup.h
@@ -54,8 +54,8 @@ public:
 	IBoneSetup( const CStudioHdr *pStudioHdr, int boneMask, const float poseParameter[], IPoseDebugger *pPoseDebugger = NULL );
 	~IBoneSetup( void );
 	void InitPose( Vector pos[], Quaternion[] );
-	void AccumulatePose( Vector pos[], Quaternion q[], int sequence, float cycle, float flWeight, float flTime, CIKContext *pIKContext );
-	void CalcAutoplaySequences(	Vector pos[], Quaternion q[], float flRealTime, CIKContext *pIKContext );
+	void AccumulatePose( Vector pos[], Quaternion q[], int sequence, float cycle, float flWeight, double flTime, CIKContext *pIKContext );
+	void CalcAutoplaySequences(	Vector pos[], Quaternion q[], double flRealTime, CIKContext *pIKContext );
 	void CalcBoneAdj( Vector pos[], Quaternion q[], const float controllers[] );
 	CStudioHdr *GetStudioHdr();
 private:
@@ -384,7 +384,7 @@ struct bonecacheparams_t
 {
 	CStudioHdr		*pStudioHdr;
 	matrix3x4_t		*pBoneToWorld;
-	float			curtime;
+	double			curtime;
 	int				boneMask;
 };
 
@@ -408,15 +408,15 @@ public:
 	// was constructor, but placement new is messy wrt memdebug - so cast & init instead
 	void			Init( const bonecacheparams_t &params, unsigned int size, short *pStudioToCached, short *pCachedToStudio, int cachedBoneCount );
 	
-	void			UpdateBones( const matrix3x4_t *pBoneToWorld, int numbones, float curtime );
+	void			UpdateBones( const matrix3x4_t *pBoneToWorld, int numbones, double curtime );
 	matrix3x4_t		*GetCachedBone( int studioIndex );
 	void			ReadCachedBones( matrix3x4_t *pBoneToWorld );
 	void			ReadCachedBonePointers( matrix3x4_t **bones, int numbones );
 
-	bool			IsValid( float curtime, float dt = 0.1f );
+	bool			IsValid( double curtime, float dt = 0.1f );
 
 public:
-	float			m_timeValid;
+	double			m_timeValid;
 	int				m_boneMask;
 
 private:

--- a/public/cdll_int.h
+++ b/public/cdll_int.h
@@ -251,10 +251,10 @@ public:
 	virtual const model_t		*LoadModel( const char *pName, bool bProp = false ) = 0;
 
 	// Get accurate, sub-frame clock ( profiling use )
-	virtual float				Time( void ) = 0; 
+	virtual double				Time( void ) = 0; 
 
 	// Get the exact server timesstamp ( server time ) from the last message received from the server
-	virtual float				GetLastTimeStamp( void ) = 0; 
+	virtual double				GetLastTimeStamp( void ) = 0; 
 
 	// Given a CAudioSource (opaque pointer), retrieve the underlying CSentence object ( stores the words, phonemes, and close
 	//  captioning data )

--- a/public/datamap.h
+++ b/public/datamap.h
@@ -64,6 +64,11 @@ typedef enum _fieldtypes
 	FIELD_MATERIALINDEX,	// a material index (using the material precache string table)
 	
 	FIELD_VECTOR2D,			// 2 floats
+	
+	FIELD_UNKNOWN_1,
+	FIELD_GMODDATATABLE,
+	FIELD_UNKNOWN_2,
+	FIELD_TIME64,			// Double
 
 	FIELD_TYPECOUNT,		// MUST BE LAST
 } fieldtype_t;

--- a/public/dlight.h
+++ b/public/dlight.h
@@ -46,7 +46,7 @@ struct dlight_t
 	Vector	origin;
 	float	radius;
 	ColorRGBExp32	color;		// Light color with exponent
-	float	die;				// stop lighting after this time
+	double	die;				// stop lighting after this time
 	float	decay;				// drop this each second
 	float	minlight;			// don't add when contributing less
 	int		key;

--- a/public/dt_common.h
+++ b/public/dt_common.h
@@ -134,7 +134,7 @@ typedef enum
 class DVariant
 {
 public:
-				DVariant()				{m_Type = DPT_Float;}
+				DVariant()				{m_Type = DPT_Float; m_pData = nullptr;}
 				DVariant(float val)		{m_Type = DPT_Float; m_Float = val;}
 				
 				const char *ToString()

--- a/public/dt_common.h
+++ b/public/dt_common.h
@@ -139,7 +139,7 @@ public:
 				
 				const char *ToString()
 				{
-					static char text[128];
+					static thread_local char text[128];
 
 					switch ( m_Type )
 					{

--- a/public/dt_send.h
+++ b/public/dt_send.h
@@ -266,7 +266,7 @@ public:
 	const char		*m_pVarName;
 	float			m_fHighLowMul;
 	
-private:
+public: // private? Not with me >:3
 
 	int					m_Flags;				// SPROP_ flags.
 

--- a/public/dt_send.h
+++ b/public/dt_send.h
@@ -265,8 +265,6 @@ public:
 
 	const char		*m_pVarName;
 	float			m_fHighLowMul;
-	
-public: // private? Not with me >:3
 
 	int					m_Flags;				// SPROP_ flags.
 

--- a/public/eiface.h
+++ b/public/eiface.h
@@ -682,7 +682,7 @@ public:
 	virtual void			ClientSpawned( edict_t *pPlayer ) = 0;
 
 	// Handles file requests and Lua errors from the client
-	virtual void 			GMOD_ReceiveClientMessage( int unknown, edict_t* pPlayer, bf_read* msg, int unknown2 ) = 0;
+	virtual void 			GMOD_ReceiveClientMessage( int userID, edict_t* pPlayer, bf_read* msg, int bits ) = 0;
 
 	virtual void 			GMOD_ClientConnected( int userID ) = 0;
 

--- a/public/eiface.h
+++ b/public/eiface.h
@@ -682,11 +682,14 @@ public:
 	virtual void			ClientSpawned( edict_t *pPlayer ) = 0;
 
 	// Handles file requests and Lua errors from the client
-	virtual void 			GMOD_ReceiveClientMessage( int userID, edict_t* pPlayer, bf_read* msg, int bits ) = 0;
+	virtual void 			GMOD_ReceiveClientMessage( int unknown, edict_t* pPlayer, bf_read* msg, int unknown2 ) = 0;
 
 	virtual void 			GMOD_ClientConnected( int userID ) = 0;
 
 	virtual void 			GMOD_SentClientStringTables( int userID ) = 0;
+
+	// Called when a voice packet is received in SV_BroadcastVoiceData
+	virtual void			GMOD_OnReceivedVoicePacket( edict_t *pPlayer ) = 0;
 };
 
 typedef IServerGameClients IServerGameClients003;

--- a/public/engine/IEngineSound.h
+++ b/public/engine/IEngineSound.h
@@ -74,15 +74,15 @@ public:
 	// player (client-side only)
 	virtual void EmitSound( IRecipientFilter& filter, int iEntIndex, int iChannel, const char *pSample, 
 		float flVolume, float flAttenuation, int iFlags = 0, int iPitch = PITCH_NORM, int iSpecialDSP = 0, 
-		const Vector *pOrigin = NULL, const Vector *pDirection = NULL, CUtlVector< Vector >* pUtlVecOrigins = NULL, bool bUpdatePositions = true, float soundtime = 0.0f, int speakerentity = -1 ) = 0;
+		const Vector *pOrigin = NULL, const Vector *pDirection = NULL, CUtlVector< Vector >* pUtlVecOrigins = NULL, bool bUpdatePositions = true, double soundtime = 0.0f, int speakerentity = -1 ) = 0;
 
 	virtual void EmitSound( IRecipientFilter& filter, int iEntIndex, int iChannel, const char *pSample, 
 		float flVolume, soundlevel_t iSoundlevel, int iFlags = 0, int iPitch = PITCH_NORM, int iSpecialDSP = 0, 
-		const Vector *pOrigin = NULL, const Vector *pDirection = NULL, CUtlVector< Vector >* pUtlVecOrigins = NULL, bool bUpdatePositions = true, float soundtime = 0.0f, int speakerentity = -1 ) = 0;
+		const Vector *pOrigin = NULL, const Vector *pDirection = NULL, CUtlVector< Vector >* pUtlVecOrigins = NULL, bool bUpdatePositions = true, double soundtime = 0.0f, int speakerentity = -1 ) = 0;
 
 	virtual void EmitSentenceByIndex( IRecipientFilter& filter, int iEntIndex, int iChannel, int iSentenceIndex, 
 		float flVolume, soundlevel_t iSoundlevel, int iFlags = 0, int iPitch = PITCH_NORM,int iSpecialDSP = 0, 
-		const Vector *pOrigin = NULL, const Vector *pDirection = NULL, CUtlVector< Vector >* pUtlVecOrigins = NULL, bool bUpdatePositions = true, float soundtime = 0.0f, int speakerentity = -1 ) = 0;
+		const Vector *pOrigin = NULL, const Vector *pDirection = NULL, CUtlVector< Vector >* pUtlVecOrigins = NULL, bool bUpdatePositions = true, double soundtime = 0.0f, int speakerentity = -1 ) = 0;
 
 	virtual void StopSound( int iEntIndex, int iChannel, const char *pSample ) = 0;
 
@@ -97,7 +97,7 @@ public:
 	
 	// emit an "ambient" sound that isn't spatialized
 	// only available on the client, assert on server
-	virtual void EmitAmbientSound( const char *pSample, float flVolume, int iPitch = PITCH_NORM, int flags = 0, float soundtime = 0.0f ) = 0;
+	virtual void EmitAmbientSound( const char *pSample, float flVolume, int iPitch = PITCH_NORM, int flags = 0, double soundtime = 0.0f ) = 0;
 
 
 //	virtual EntChannel_t	CreateEntChannel() = 0;

--- a/public/filesystem.h
+++ b/public/filesystem.h
@@ -518,9 +518,9 @@ public:
 
 
 	virtual void				Seek( FileHandle_t file, long long pos, FileSystemSeek_t seekType ) = 0;
-	virtual unsigned long long	Tell( FileHandle_t file ) = 0;
-	virtual unsigned long long	Size( FileHandle_t file ) = 0;
-	virtual unsigned long long	Size( const char *pFileName, const char *pPathID = 0 ) = 0;
+	virtual unsigned int		Tell( FileHandle_t file ) = 0;
+	virtual unsigned int		Size( FileHandle_t file ) = 0;
+	virtual unsigned int		Size( const char *pFileName, const char *pPathID = 0 ) = 0;
 
 	virtual void			Flush( FileHandle_t file ) = 0;
 	virtual bool			Precache( const char *pFileName, const char *pPathID = 0 ) = 0;

--- a/public/filesystem_base.h
+++ b/public/filesystem_base.h
@@ -339,9 +339,9 @@ public:
 	virtual FileHandle_t OpenEx( const char *pFileName, const char *pOptions, unsigned flags = 0, const char *pathID = nullptr, char **ppszResolvedFilename = nullptr ) = 0;
 	virtual void Close( FileHandle_t file ) = 0;
 	virtual void Seek( FileHandle_t file, long long pos, FileSystemSeek_t seekType ) = 0;
-	virtual unsigned long long Tell( FileHandle_t file ) = 0;
-	virtual unsigned long long Size( FileHandle_t file ) = 0;
-	virtual unsigned long long Size( const char *pFileName, const char *pPathID = nullptr ) = 0;
+	virtual unsigned int Tell( FileHandle_t file ) = 0;
+	virtual unsigned int Size( FileHandle_t file ) = 0;
+	virtual unsigned int Size( const char *pFileName, const char *pPathID = nullptr ) = 0;
 
 	virtual void SetBufferSize( FileHandle_t file, unsigned nBytes ) = 0;
 	virtual bool IsOk( FileHandle_t file ) = 0;

--- a/public/filesystem_passthru.h
+++ b/public/filesystem_passthru.h
@@ -44,9 +44,9 @@ public:
 	virtual FileHandle_t	Open( const char *pFileName, const char *pOptions, const char *pathID )		{ return m_pBaseFileSystemPassThru->Open( pFileName, pOptions, pathID ); }
 	virtual void			Close( FileHandle_t file )													{ m_pBaseFileSystemPassThru->Close( file ); }
 	virtual void			Seek( FileHandle_t file, long long pos, FileSystemSeek_t seekType )			{ m_pBaseFileSystemPassThru->Seek( file, pos, seekType ); }
-	virtual unsigned long long	Tell( FileHandle_t file )												{ return m_pBaseFileSystemPassThru->Tell( file ); }
-	virtual unsigned long long	Size( FileHandle_t file )												{ return m_pBaseFileSystemPassThru->Size( file ); }
-	virtual unsigned long long	Size( const char *pFileName, const char *pPathID )						{ return m_pBaseFileSystemPassThru->Size( pFileName, pPathID ); }
+	virtual unsigned int	Tell( FileHandle_t file )													{ return m_pBaseFileSystemPassThru->Tell( file ); }
+	virtual unsigned int	Size( FileHandle_t file )													{ return m_pBaseFileSystemPassThru->Size( file ); }
+	virtual unsigned int	Size( const char *pFileName, const char *pPathID )							{ return m_pBaseFileSystemPassThru->Size( pFileName, pPathID ); }
 	virtual void			Flush( FileHandle_t file )													{ m_pBaseFileSystemPassThru->Flush( file ); }
 	virtual bool			Precache( const char *pFileName, const char *pPathID )						{ return m_pBaseFileSystemPassThru->Precache( pFileName, pPathID ); }
 	virtual bool			FileExists( const char *pFileName, const char *pPathID )					{ return m_pBaseFileSystemPassThru->FileExists( pFileName, pPathID ); }

--- a/public/globalvars_base.h
+++ b/public/globalvars_base.h
@@ -53,7 +53,7 @@ public:
 	//
 	//   - During prediction, this is based on the client's current tick:
 	//     [client_current_tick * tick_interval]
-	float			curtime;
+	double			curtime;
 	
 	// Time spent on last server or client frame (has nothing to do with think intervals)
 	float			frametime;
@@ -64,7 +64,7 @@ public:
 	int				tickcount;
 
 	// Simulation tick interval
-	float			interval_per_tick;
+	double			interval_per_tick;
 
 	// interpolation amount ( client-only ) based on fraction of next tick which has elapsed
 	float			interpolation_amount;

--- a/public/globalvars_base.h
+++ b/public/globalvars_base.h
@@ -53,7 +53,7 @@ public:
 	//
 	//   - During prediction, this is based on the client's current tick:
 	//     [client_current_tick * tick_interval]
-	double			curtime;
+	float			curtime;
 	
 	// Time spent on last server or client frame (has nothing to do with think intervals)
 	float			frametime;
@@ -64,7 +64,7 @@ public:
 	int				tickcount;
 
 	// Simulation tick interval
-	double			interval_per_tick;
+	float			interval_per_tick;
 
 	// interpolation amount ( client-only ) based on fraction of next tick which has elapsed
 	float			interpolation_amount;

--- a/public/iclientrenderable.h
+++ b/public/iclientrenderable.h
@@ -104,7 +104,7 @@ public:
 	// currentTime parameter will affect interpolation
 	// nMaxBones specifies how many matrices pBoneToWorldOut can hold. (Should be greater than or
 	// equal to studiohdr_t::numbones. Use MAXSTUDIOBONES to be safe.)
-	virtual bool	SetupBones( matrix3x4_t *pBoneToWorldOut, int nMaxBones, int boneMask, float currentTime ) = 0;
+	virtual bool	SetupBones( matrix3x4_t *pBoneToWorldOut, int nMaxBones, int boneMask, double currentTime ) = 0;
 
 	virtual void	SetupWeights( const matrix3x4_t *pBoneToWorld, int nFlexWeightCount, float *pFlexWeights, float *pFlexDelayedWeights ) = 0;
 	virtual void	DoAnimationEvents( void ) = 0;
@@ -212,7 +212,7 @@ public:
 	virtual void					ComputeFxBlend( )		{ return; }
 	virtual int						GetFxBlend( )			{ return 255; }
 	virtual bool					LODTest()				{ return true; }
-	virtual bool					SetupBones( matrix3x4_t *pBoneToWorldOut, int nMaxBones, int boneMask, float currentTime )	{ return true; }
+	virtual bool					SetupBones( matrix3x4_t *pBoneToWorldOut, int nMaxBones, int boneMask, double currentTime )	{ return true; }
 	virtual void					SetupWeights( const matrix3x4_t *pBoneToWorld, int nFlexWeightCount, float *pFlexWeights, float *pFlexDelayedWeights ) {}
 	virtual void					DoAnimationEvents( void )						{}
 	virtual IPVSNotify*				GetPVSNotifyInterface() { return NULL; }

--- a/public/igameevents.h
+++ b/public/igameevents.h
@@ -83,7 +83,6 @@ public:
 	virtual void SetFloat( const char *keyName, float value ) = 0;
 	virtual void SetString( const char *keyName, const char *value ) = 0;
 
-	// Gmod custom one
 	virtual KeyValues* GetKeyValues() = 0;
 };
 

--- a/public/igameevents.h
+++ b/public/igameevents.h
@@ -82,6 +82,9 @@ public:
 	virtual void SetInt( const char *keyName, int value ) = 0;
 	virtual void SetFloat( const char *keyName, float value ) = 0;
 	virtual void SetString( const char *keyName, const char *value ) = 0;
+
+	// Gmod custom one
+	virtual KeyValues* GetKeyValues() = 0;
 };
 
 

--- a/public/iserver.h
+++ b/public/iserver.h
@@ -32,9 +32,9 @@ public:
 	virtual IClient	*GetClient( int index ) = 0; // returns interface to client 
 	virtual int		GetClientCount() const = 0; // returns number of clients slots (used & unused)
 	virtual int		GetUDPPort( void ) const = 0; // returns current used UDP port
-	virtual float	GetTime( void ) const = 0;	// returns game world time
+	virtual double	GetTime( void ) const = 0;	// returns game world time
 	virtual int		GetTick( void ) const = 0;	// returns game world tick
-	virtual float	GetTickInterval( void ) const = 0; // tick interval in seconds
+	virtual double	GetTickInterval( void ) const = 0; // tick interval in seconds
 	virtual const char *GetName( void ) const = 0;	// public server name
 	virtual const char *GetMapName( void ) const = 0; // current map name (BSP)
 	virtual int		GetSpawnCount( void ) const = 0;	

--- a/public/iserver.h
+++ b/public/iserver.h
@@ -32,9 +32,9 @@ public:
 	virtual IClient	*GetClient( int index ) = 0; // returns interface to client 
 	virtual int		GetClientCount() const = 0; // returns number of clients slots (used & unused)
 	virtual int		GetUDPPort( void ) const = 0; // returns current used UDP port
-	virtual double	GetTime( void ) const = 0;	// returns game world time
+	virtual float	GetTime( void ) const = 0;	// returns game world time
 	virtual int		GetTick( void ) const = 0;	// returns game world tick
-	virtual double	GetTickInterval( void ) const = 0; // tick interval in seconds
+	virtual float	GetTickInterval( void ) const = 0; // tick interval in seconds
 	virtual const char *GetName( void ) const = 0;	// public server name
 	virtual const char *GetMapName( void ) const = 0; // current map name (BSP)
 	virtual int		GetSpawnCount( void ) const = 0;	

--- a/public/tier0/threadtools.h
+++ b/public/tier0/threadtools.h
@@ -1539,7 +1539,8 @@ extern "C"
 
 //---------------------------------------------------------
 
-inline void CThreadMutex::Lock()
+// On Windows, these are already packed inside the tier0.lib so we don't define them here as else we would conflict!
+/*inline void CThreadMutex::Lock()
 {
 #ifdef THREAD_MUTEX_TRACING_ENABLED
 		uint thisThreadID = ThreadGetCurrentId();
@@ -1576,7 +1577,7 @@ inline void CThreadMutex::Unlock()
 		}
 	#endif
 	LeaveCriticalSection((CRITICAL_SECTION *)&m_CriticalSection);
-}
+}*/
 
 //---------------------------------------------------------
 

--- a/public/tier0/threadtools.h
+++ b/public/tier0/threadtools.h
@@ -1127,7 +1127,7 @@ private:
 class ALIGN8 PLATFORM_CLASS CThreadSpinRWLock
 {
 public:
-#ifdef WIN32
+#ifdef _WIN32
 	CThreadSpinRWLock();
 #else
 	CThreadSpinRWLock() { COMPILE_TIME_ASSERT( sizeof( LockInfo_t ) == sizeof( int64 ) ); Assert( (intp)this % 8 == 0 ); memset( this, 0, sizeof( *this ) ); }
@@ -1145,7 +1145,7 @@ public:
 	bool TryLockForRead() const { return const_cast<CThreadSpinRWLock *>(this)->TryLockForRead(); }
 	void LockForRead() const { const_cast<CThreadSpinRWLock *>(this)->LockForRead(); }
 	void UnlockRead() const { const_cast<CThreadSpinRWLock *>(this)->UnlockRead(); }
-#ifdef WIN32
+#ifdef _WIN32
 	void LockForWrite() const; // { const_cast<CThreadSpinRWLock *>(this)->LockForWrite(); }
 #else
 	void LockForWrite() const { const_cast<CThreadSpinRWLock *>(this)->LockForWrite(); }
@@ -1540,7 +1540,8 @@ extern "C"
 //---------------------------------------------------------
 
 // On Windows, these are already packed inside the tier0.lib so we don't define them here as else we would conflict!
-/*inline void CThreadMutex::Lock()
+#ifndef _WIN32
+inline void CThreadMutex::Lock()
 {
 #ifdef THREAD_MUTEX_TRACING_ENABLED
 		uint thisThreadID = ThreadGetCurrentId();
@@ -1577,7 +1578,8 @@ inline void CThreadMutex::Unlock()
 		}
 	#endif
 	LeaveCriticalSection((CRITICAL_SECTION *)&m_CriticalSection);
-}*/
+}
+#endif
 
 //---------------------------------------------------------
 
@@ -1757,7 +1759,7 @@ inline bool CThreadSpinRWLock::TryLockForRead()
 	return bSuccess;
 }
 
-#ifndef WIN32
+#ifndef _WIN32
 inline void CThreadSpinRWLock::LockForWrite()
 {
 	const uint32 threadId = ThreadGetCurrentId();

--- a/public/tier1/convar.h
+++ b/public/tier1/convar.h
@@ -175,8 +175,8 @@ protected:
 
 public:
 	inline ConCommandBase* InternalNext() { return m_pNext; };
-	inline ConCommandBase* InternalConCommandBases() { return s_pConCommandBases; };
-	inline IConCommandBaseAccessor* InternalBaseAccessor() { return s_pAccessor; };
+	static inline ConCommandBase* InternalConCommandBases() { return s_pConCommandBases; };
+	static inline IConCommandBaseAccessor* InternalBaseAccessor() { return s_pAccessor; };
 };
 
 

--- a/public/tier1/convar.h
+++ b/public/tier1/convar.h
@@ -136,6 +136,11 @@ public:
 	// Returns the DLL identifier
 	virtual CVarDLLIdentifier_t	GetDLLIdentifier() const;
 
+	inline ConCommandBase* InternalNext() { return m_pNext; }
+
+	static inline ConCommandBase* InternalConCommandBases() { return s_pConCommandBases; }
+	static inline IConCommandBaseAccessor* InternalBaseAccessor() { return s_pAccessor; }
+
 protected:
 	virtual void				CreateBase( const char *pName, const char *pHelpString = 0, 
 									int flags = 0 );
@@ -172,11 +177,6 @@ protected:
 
 	// ConVars in this executable use this 'global' to access values.
 	static IConCommandBaseAccessor	*s_pAccessor;
-
-public:
-	inline ConCommandBase* InternalNext() { return m_pNext; };
-	static inline ConCommandBase* InternalConCommandBases() { return s_pConCommandBases; };
-	static inline IConCommandBaseAccessor* InternalBaseAccessor() { return s_pAccessor; };
 };
 
 

--- a/public/tier1/convar.h
+++ b/public/tier1/convar.h
@@ -172,6 +172,11 @@ protected:
 
 	// ConVars in this executable use this 'global' to access values.
 	static IConCommandBaseAccessor	*s_pAccessor;
+
+public:
+	inline ConCommandBase* InternalNext() { return m_pNext; };
+	inline ConCommandBase* InternalConCommandBases() { return s_pConCommandBases; };
+	inline IConCommandBaseAccessor* InternalBaseAccessor() { return s_pAccessor; };
 };
 
 
@@ -568,6 +573,13 @@ FORCEINLINE_CVAR const char *ConVarRef::GetDefault() const
 void ConVar_Register( int nCVarFlag = 0, IConCommandBaseAccessor *pAccessor = NULL );
 void ConVar_Unregister( );
 
+//-----------------------------------------------------------------------------
+// Utility methods when implementing your custom ConVar_Register function.
+//-----------------------------------------------------------------------------
+int* ConVar_GetConVarFlag();
+int* ConVar_GetDLLIdentifier();
+bool* ConVar_GetIsRegistered();
+IConCommandBaseAccessor* ConVar_GetDefaultAccessor();
 
 //-----------------------------------------------------------------------------
 // Utility methods 

--- a/public/vphysics_interface.h
+++ b/public/vphysics_interface.h
@@ -854,6 +854,9 @@ public:
 	// dumps info about the object to Msg()
 	virtual void			OutputDebugInfo() const = 0;
 
+	// Returns the buoyancy of the object.
+	// Newly added by Valve since it was requested by Rubat to solve https://github.com/Facepunch/garrysmod-issues/issues/5696
+	virtual float			GetBuoyancyRatio( void ) const = 0;
 };
 
 

--- a/tier1/convar.cpp
+++ b/tier1/convar.cpp
@@ -29,8 +29,6 @@
 #define ALLOW_DEVELOPMENT_CVARS
 #endif
 
-
-
 //-----------------------------------------------------------------------------
 // Statically constructed list of ConCommandBases, 
 // used for registering them with the ICVar interface
@@ -40,6 +38,21 @@ IConCommandBaseAccessor	*ConCommandBase::s_pAccessor = NULL;
 static int s_nCVarFlag = 0;
 static int s_nDLLIdentifier = -1;	// A unique identifier indicating which DLL this convar came from
 static bool s_bRegistered = false;
+
+int* ConVar_GetConVarFlag()
+{
+	return &s_nCVarFlag;
+}
+
+int* ConVar_GetDLLIdentifier()
+{
+	return &s_nDLLIdentifier;
+}
+
+bool* ConVar_GetIsRegistered()
+{
+	return &s_bRegistered;
+}
 
 class CDefaultAccessor : public IConCommandBaseAccessor
 {
@@ -54,6 +67,12 @@ public:
 
 static CDefaultAccessor s_DefaultAccessor;
 
+IConCommandBaseAccessor* ConVar_GetDefaultAccessor()
+{
+	return &s_DefaultAccessor;
+}
+
+#ifndef TIER0_CUSTOMCONVARREGISTER
 //-----------------------------------------------------------------------------
 // Called by the framework to register ConCommandBases with the ICVar
 //-----------------------------------------------------------------------------
@@ -82,7 +101,9 @@ void ConVar_Register( int nCVarFlag, IConCommandBaseAccessor *pAccessor )
 	g_pCVar->ProcessQueuedMaterialThreadConVarSets();
 	ConCommandBase::s_pConCommandBases = NULL;
 }
+#endif
 
+#ifndef TIER0_CUSTOMCONVARUNREGISTER
 void ConVar_Unregister( )
 {
 	if ( !g_pCVar || !s_bRegistered )
@@ -93,7 +114,7 @@ void ConVar_Unregister( )
 	s_nDLLIdentifier = -1;
 	s_bRegistered = false;
 }
-
+#endif
 
 //-----------------------------------------------------------------------------
 // Purpose: Default constructor

--- a/tier1/convar.cpp
+++ b/tier1/convar.cpp
@@ -851,7 +851,10 @@ void ConVar::ChangeStringValue( const char *tempVal, float flOldValue )
 			m_fnChangeCallback( this, pszOldValue, flOldValue );
 		}
 
-		g_pCVar->CallGlobalChangeCallbacks( this, pszOldValue, flOldValue );
+		if ( g_pCVar )
+		{
+			g_pCVar->CallGlobalChangeCallbacks( this, pszOldValue, flOldValue );
+		}
 	}
 
 	stackfree( pszOldValue );

--- a/tier1/convar.cpp
+++ b/tier1/convar.cpp
@@ -29,6 +29,8 @@
 #define ALLOW_DEVELOPMENT_CVARS
 #endif
 
+
+
 //-----------------------------------------------------------------------------
 // Statically constructed list of ConCommandBases, 
 // used for registering them with the ICVar interface
@@ -72,7 +74,6 @@ IConCommandBaseAccessor* ConVar_GetDefaultAccessor()
 	return &s_DefaultAccessor;
 }
 
-#ifndef TIER1_CUSTOMCONVARREGISTER
 //-----------------------------------------------------------------------------
 // Called by the framework to register ConCommandBases with the ICVar
 //-----------------------------------------------------------------------------
@@ -101,9 +102,7 @@ void ConVar_Register( int nCVarFlag, IConCommandBaseAccessor *pAccessor )
 	g_pCVar->ProcessQueuedMaterialThreadConVarSets();
 	ConCommandBase::s_pConCommandBases = NULL;
 }
-#endif
 
-#ifndef TIER1_CUSTOMCONVARUNREGISTER
 void ConVar_Unregister( )
 {
 	if ( !g_pCVar || !s_bRegistered )
@@ -114,7 +113,7 @@ void ConVar_Unregister( )
 	s_nDLLIdentifier = -1;
 	s_bRegistered = false;
 }
-#endif
+
 
 //-----------------------------------------------------------------------------
 // Purpose: Default constructor

--- a/tier1/convar.cpp
+++ b/tier1/convar.cpp
@@ -72,7 +72,7 @@ IConCommandBaseAccessor* ConVar_GetDefaultAccessor()
 	return &s_DefaultAccessor;
 }
 
-#ifndef TIER0_CUSTOMCONVARREGISTER
+#ifndef TIER1_CUSTOMCONVARREGISTER
 //-----------------------------------------------------------------------------
 // Called by the framework to register ConCommandBases with the ICVar
 //-----------------------------------------------------------------------------
@@ -103,7 +103,7 @@ void ConVar_Register( int nCVarFlag, IConCommandBaseAccessor *pAccessor )
 }
 #endif
 
-#ifndef TIER0_CUSTOMCONVARUNREGISTER
+#ifndef TIER1_CUSTOMCONVARUNREGISTER
 void ConVar_Unregister( )
 {
 	if ( !g_pCVar || !s_bRegistered )

--- a/tier1/keyvalues.cpp
+++ b/tier1/keyvalues.cpp
@@ -703,7 +703,7 @@ bool KeyValues::LoadFromFile( IBaseFileSystem *filesystem, const char *resourceN
 	s_LastFileLoadingFrom = (char*)resourceName;
 
 	// load file into a null-terminated buffer
-	int fileSize = filesystem->Size( f );
+	int fileSize = (int)filesystem->Size( f );
 	unsigned bufSize = ((IFileSystem *)filesystem)->GetOptimalReadSize( f, fileSize + 2 );
 
 	char *buffer = (char*)((IFileSystem *)filesystem)->AllocOptimalReadBuffer( f, bufSize );

--- a/tier1/keyvalues.cpp
+++ b/tier1/keyvalues.cpp
@@ -30,7 +30,6 @@
 #include "utlqueue.h"
 #include "UtlSortVector.h"
 #include "convar.h"
-#include <memory>
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include <tier0/memdbgon.h>
@@ -43,7 +42,7 @@ const char *(*KeyValues::s_pfGetStringForSymbol)( int symbol ) = &KeyValues::Get
 CKeyValuesGrowableStringTable *KeyValues::s_pGrowableStringTable = NULL;
 
 #define KEYVALUES_TOKEN_SIZE	4096
-static thread_local std::unique_ptr<char[]> s_pTokenBuf(new char[KEYVALUES_TOKEN_SIZE]);
+static thread_local char s_pTokenBuf[KEYVALUES_TOKEN_SIZE];
 
 
 #define INTERNALWRITE( pData, len ) InternalWrite( filesystem, f, pBuf, pData, len )
@@ -125,7 +124,7 @@ private:
 	int		m_maxErrorIndex;
 };
 
-static thread_local auto g_KeyValuesErrorStack = std::make_unique<CKeyValuesErrorStack>();
+static thread_local CKeyValuesErrorStack g_KeyValuesErrorStack;
 
 
 // a simple helper that creates stack entries as it goes in & out of scope
@@ -139,7 +138,7 @@ public:
 
 	~CKeyErrorContext()
 	{
-		g_KeyValuesErrorStack.get()->Pop();
+		g_KeyValuesErrorStack.Pop();
 	}
 	CKeyErrorContext( int symName )
 	{
@@ -147,7 +146,7 @@ public:
 	}
 	void Reset( int symName )
 	{
-		g_KeyValuesErrorStack.get()->Reset( m_stackLevel, symName );
+		g_KeyValuesErrorStack.Reset( m_stackLevel, symName );
 	}
 	int GetStackLevel() const
 	{
@@ -156,7 +155,7 @@ public:
 private:
 	void Init( int symName )
 	{
-		m_stackLevel = g_KeyValuesErrorStack.get()->Push( symName );
+		m_stackLevel = g_KeyValuesErrorStack.Push( symName );
 	}
 
 	int m_stackLevel;
@@ -562,24 +561,22 @@ const char *KeyValues::ReadToken( CUtlBuffer &buf, bool &wasQuoted, bool &wasCon
 	if ( !c )
 		return NULL;
 
-	char* pTokenBuf = s_pTokenBuf.get();
-
 	// read quoted strings specially
 	if ( *c == '\"' )
 	{
 		wasQuoted = true;
 		buf.GetDelimitedString( m_bHasEscapeSequences ? GetCStringCharConversion() : GetNoEscCharConversion(), 
-			pTokenBuf, KEYVALUES_TOKEN_SIZE );
-		return pTokenBuf;
+			s_pTokenBuf, KEYVALUES_TOKEN_SIZE );
+		return s_pTokenBuf;
 	}
 
 	if ( *c == '{' || *c == '}' )
 	{
 		// it's a control char, just add this one char and stop reading
-		pTokenBuf[0] = *c;
-		pTokenBuf[1] = 0;
+		s_pTokenBuf[0] = *c;
+		s_pTokenBuf[1] = 0;
 		buf.SeekGet( CUtlBuffer::SEEK_CURRENT, 1 );
-		return pTokenBuf;
+		return s_pTokenBuf;
 	}
 
 	// read in the token until we hit a whitespace or a control character
@@ -610,18 +607,18 @@ const char *KeyValues::ReadToken( CUtlBuffer &buf, bool &wasQuoted, bool &wasCon
 
 		if (nCount < (KEYVALUES_TOKEN_SIZE-1) )
 		{
-			pTokenBuf[nCount++] = *c;	// add char to buffer
+			s_pTokenBuf[nCount++] = *c;	// add char to buffer
 		}
 		else if ( !bReportedError )
 		{
 			bReportedError = true;
-			g_KeyValuesErrorStack.get()->ReportError(" ReadToken overflow" );
+			g_KeyValuesErrorStack.ReportError(" ReadToken overflow" );
 		}
 
 		buf.SeekGet( CUtlBuffer::SEEK_CURRENT, 1 );
 	}
-	pTokenBuf[ nCount ] = 0;
-	return pTokenBuf;
+	s_pTokenBuf[ nCount ] = 0;
+	return s_pTokenBuf;
 }
 #pragma warning (default:4706)
 
@@ -708,7 +705,7 @@ bool KeyValues::LoadFromFile( IBaseFileSystem *filesystem, const char *resourceN
 	s_LastFileLoadingFrom = (char*)resourceName;
 
 	// load file into a null-terminated buffer
-	int fileSize = (int)filesystem->Size( f );
+	unsigned fileSize = filesystem->Size( f );
 	unsigned bufSize = ((IFileSystem *)filesystem)->GetOptimalReadSize( f, fileSize + 2 );
 
 	char *buffer = (char*)((IFileSystem *)filesystem)->AllocOptimalReadBuffer( f, bufSize );
@@ -2244,7 +2241,7 @@ bool KeyValues::LoadFromBuffer( char const *resourceName, CUtlBuffer &buf, IBase
 	CUtlVector< KeyValues * > baseKeys;
 	bool wasQuoted;
 	bool wasConditional;
-	g_KeyValuesErrorStack.get()->SetFilename( resourceName );	
+	g_KeyValuesErrorStack.SetFilename( resourceName );	
 	do 
 	{
 		bool bAccepted = true;
@@ -2261,7 +2258,7 @@ bool KeyValues::LoadFromBuffer( char const *resourceName, CUtlBuffer &buf, IBase
 
 			if ( !s || *s == 0 )
 			{
-				g_KeyValuesErrorStack.get()->ReportError("#include is NULL " );
+				g_KeyValuesErrorStack.ReportError("#include is NULL " );
 			}
 			else
 			{
@@ -2277,7 +2274,7 @@ bool KeyValues::LoadFromBuffer( char const *resourceName, CUtlBuffer &buf, IBase
 
 			if ( !s || *s == 0 )
 			{
-				g_KeyValuesErrorStack.get()->ReportError("#base is NULL " );
+				g_KeyValuesErrorStack.ReportError("#base is NULL " );
 			}
 			else
 			{
@@ -2323,7 +2320,7 @@ bool KeyValues::LoadFromBuffer( char const *resourceName, CUtlBuffer &buf, IBase
 		}
 		else
 		{
-			g_KeyValuesErrorStack.get()->ReportError("LoadFromBuffer: missing {" );
+			g_KeyValuesErrorStack.ReportError("LoadFromBuffer: missing {" );
 		}
 
 		if ( !bAccepted )
@@ -2363,7 +2360,7 @@ bool KeyValues::LoadFromBuffer( char const *resourceName, CUtlBuffer &buf, IBase
 		}
 	}
 
-	g_KeyValuesErrorStack.get()->SetFilename( "" );	
+	g_KeyValuesErrorStack.SetFilename( "" );	
 
 	return true;
 }
@@ -2408,7 +2405,7 @@ void KeyValues::RecursiveLoadFromBuffer( char const *resourceName, CUtlBuffer &b
 	bool wasConditional;
 	if ( errorReport.GetStackLevel() > 100 )
 	{
-		g_KeyValuesErrorStack.get()->ReportError( "RecursiveLoadFromBuffer:  recursion overflow" );
+		g_KeyValuesErrorStack.ReportError( "RecursiveLoadFromBuffer:  recursion overflow" );
 		return;
 	}
 
@@ -2430,13 +2427,13 @@ void KeyValues::RecursiveLoadFromBuffer( char const *resourceName, CUtlBuffer &b
 
 		if ( !name )	// EOF stop reading
 		{
-			g_KeyValuesErrorStack.get()->ReportError("RecursiveLoadFromBuffer:  got EOF instead of keyname" );
+			g_KeyValuesErrorStack.ReportError("RecursiveLoadFromBuffer:  got EOF instead of keyname" );
 			break;
 		}
 
 		if ( !*name ) // empty token, maybe "" or EOF
 		{
-			g_KeyValuesErrorStack.get()->ReportError("RecursiveLoadFromBuffer:  got empty keyname" );
+			g_KeyValuesErrorStack.ReportError("RecursiveLoadFromBuffer:  got empty keyname" );
 			break;
 		}
 
@@ -2462,13 +2459,13 @@ void KeyValues::RecursiveLoadFromBuffer( char const *resourceName, CUtlBuffer &b
 
 		if ( !value )
 		{
-			g_KeyValuesErrorStack.get()->ReportError("RecursiveLoadFromBuffer:  got NULL key" );
+			g_KeyValuesErrorStack.ReportError("RecursiveLoadFromBuffer:  got NULL key" );
 			break;
 		}
 		
 		if ( *value == '}' && !wasQuoted )
 		{
-			g_KeyValuesErrorStack.get()->ReportError("RecursiveLoadFromBuffer:  got } in key" );
+			g_KeyValuesErrorStack.ReportError("RecursiveLoadFromBuffer:  got } in key" );
 			break;
 		}
 
@@ -2483,7 +2480,7 @@ void KeyValues::RecursiveLoadFromBuffer( char const *resourceName, CUtlBuffer &b
 		{
 			if ( wasConditional )
 			{
-				g_KeyValuesErrorStack.get()->ReportError("RecursiveLoadFromBuffer:  got conditional between key and value" );
+				g_KeyValuesErrorStack.ReportError("RecursiveLoadFromBuffer:  got conditional between key and value" );
 				break;
 			}
 			

--- a/tier1/keyvalues.cpp
+++ b/tier1/keyvalues.cpp
@@ -34,7 +34,7 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include <tier0/memdbgon.h>
 
-static thread_local const char * s_LastFileLoadingFrom = "unknown"; // just needed for error messages
+static const char * s_LastFileLoadingFrom = "unknown"; // just needed for error messages
 
 // Statics for the growable string table
 int (*KeyValues::s_pfGetSymbolForString)( const char *name, bool bCreate ) = &KeyValues::GetSymbolForStringClassic;
@@ -42,7 +42,7 @@ const char *(*KeyValues::s_pfGetStringForSymbol)( int symbol ) = &KeyValues::Get
 CKeyValuesGrowableStringTable *KeyValues::s_pGrowableStringTable = NULL;
 
 #define KEYVALUES_TOKEN_SIZE	4096
-static thread_local char s_pTokenBuf[KEYVALUES_TOKEN_SIZE];
+static char s_pTokenBuf[KEYVALUES_TOKEN_SIZE];
 
 
 #define INTERNALWRITE( pData, len ) InternalWrite( filesystem, f, pBuf, pData, len )
@@ -122,7 +122,7 @@ private:
 	const char *m_pFilename;
 	int		m_errorIndex;
 	int		m_maxErrorIndex;
-} thread_local g_KeyValuesErrorStack;
+} g_KeyValuesErrorStack;
 
 
 // a simple helper that creates stack entries as it goes in & out of scope
@@ -209,7 +209,7 @@ public:
 	CUtlVector< kve > keys;
 };
 
-static thread_local CLeakTrack track; // RaphaelIT7: Would probably be better to use a mutex or something... but it would be slower :sob:
+static CLeakTrack track;
 
 #define TRACK_KV_ADD( ptr, name )	track.AddKv( ptr, name )
 #define TRACK_KV_REMOVE( ptr )		track.RemoveKv( ptr )

--- a/tier1/keyvalues.cpp
+++ b/tier1/keyvalues.cpp
@@ -31,6 +31,9 @@
 #include "UtlSortVector.h"
 #include "convar.h"
 
+#include <memory>
+#include <vector>
+
 // memdbgon must be the last include file in a .cpp file!!!
 #include <tier0/memdbgon.h>
 
@@ -42,7 +45,7 @@ const char *(*KeyValues::s_pfGetStringForSymbol)( int symbol ) = &KeyValues::Get
 CKeyValuesGrowableStringTable *KeyValues::s_pGrowableStringTable = NULL;
 
 #define KEYVALUES_TOKEN_SIZE	4096
-static thread_local char s_pTokenBuf[KEYVALUES_TOKEN_SIZE];
+static thread_local std::vector<char> s_pTokenBuf(KEYVALUES_TOKEN_SIZE);
 
 
 #define INTERNALWRITE( pData, len ) InternalWrite( filesystem, f, pBuf, pData, len )
@@ -124,7 +127,7 @@ private:
 	int		m_maxErrorIndex;
 };
 
-static thread_local CKeyValuesErrorStack g_KeyValuesErrorStack;
+static thread_local auto g_KeyValuesErrorStack = std::make_unique<CKeyValuesErrorStack>();
 
 
 // a simple helper that creates stack entries as it goes in & out of scope
@@ -138,7 +141,7 @@ public:
 
 	~CKeyErrorContext()
 	{
-		g_KeyValuesErrorStack.Pop();
+		g_KeyValuesErrorStack->Pop();
 	}
 	CKeyErrorContext( int symName )
 	{
@@ -146,7 +149,7 @@ public:
 	}
 	void Reset( int symName )
 	{
-		g_KeyValuesErrorStack.Reset( m_stackLevel, symName );
+		g_KeyValuesErrorStack->Reset( m_stackLevel, symName );
 	}
 	int GetStackLevel() const
 	{
@@ -155,7 +158,7 @@ public:
 private:
 	void Init( int symName )
 	{
-		m_stackLevel = g_KeyValuesErrorStack.Push( symName );
+		m_stackLevel = g_KeyValuesErrorStack->Push( symName );
 	}
 
 	int m_stackLevel;
@@ -561,22 +564,24 @@ const char *KeyValues::ReadToken( CUtlBuffer &buf, bool &wasQuoted, bool &wasCon
 	if ( !c )
 		return NULL;
 
+	char* pTokenBuf = s_pTokenBuf.data();
+
 	// read quoted strings specially
 	if ( *c == '\"' )
 	{
 		wasQuoted = true;
 		buf.GetDelimitedString( m_bHasEscapeSequences ? GetCStringCharConversion() : GetNoEscCharConversion(), 
-			s_pTokenBuf, KEYVALUES_TOKEN_SIZE );
-		return s_pTokenBuf;
+			pTokenBuf, KEYVALUES_TOKEN_SIZE );
+		return pTokenBuf;
 	}
 
 	if ( *c == '{' || *c == '}' )
 	{
 		// it's a control char, just add this one char and stop reading
-		s_pTokenBuf[0] = *c;
-		s_pTokenBuf[1] = 0;
+		pTokenBuf[0] = *c;
+		pTokenBuf[1] = 0;
 		buf.SeekGet( CUtlBuffer::SEEK_CURRENT, 1 );
-		return s_pTokenBuf;
+		return pTokenBuf;
 	}
 
 	// read in the token until we hit a whitespace or a control character
@@ -607,18 +612,18 @@ const char *KeyValues::ReadToken( CUtlBuffer &buf, bool &wasQuoted, bool &wasCon
 
 		if (nCount < (KEYVALUES_TOKEN_SIZE-1) )
 		{
-			s_pTokenBuf[nCount++] = *c;	// add char to buffer
+			pTokenBuf[nCount++] = *c;	// add char to buffer
 		}
 		else if ( !bReportedError )
 		{
 			bReportedError = true;
-			g_KeyValuesErrorStack.ReportError(" ReadToken overflow" );
+			g_KeyValuesErrorStack->ReportError(" ReadToken overflow" );
 		}
 
 		buf.SeekGet( CUtlBuffer::SEEK_CURRENT, 1 );
 	}
-	s_pTokenBuf[ nCount ] = 0;
-	return s_pTokenBuf;
+	pTokenBuf[ nCount ] = 0;
+	return pTokenBuf;
 }
 #pragma warning (default:4706)
 
@@ -2241,7 +2246,7 @@ bool KeyValues::LoadFromBuffer( char const *resourceName, CUtlBuffer &buf, IBase
 	CUtlVector< KeyValues * > baseKeys;
 	bool wasQuoted;
 	bool wasConditional;
-	g_KeyValuesErrorStack.SetFilename( resourceName );	
+	g_KeyValuesErrorStack->SetFilename( resourceName );	
 	do 
 	{
 		bool bAccepted = true;
@@ -2258,7 +2263,7 @@ bool KeyValues::LoadFromBuffer( char const *resourceName, CUtlBuffer &buf, IBase
 
 			if ( !s || *s == 0 )
 			{
-				g_KeyValuesErrorStack.ReportError("#include is NULL " );
+				g_KeyValuesErrorStack->ReportError("#include is NULL " );
 			}
 			else
 			{
@@ -2274,7 +2279,7 @@ bool KeyValues::LoadFromBuffer( char const *resourceName, CUtlBuffer &buf, IBase
 
 			if ( !s || *s == 0 )
 			{
-				g_KeyValuesErrorStack.ReportError("#base is NULL " );
+				g_KeyValuesErrorStack->ReportError("#base is NULL " );
 			}
 			else
 			{
@@ -2320,7 +2325,7 @@ bool KeyValues::LoadFromBuffer( char const *resourceName, CUtlBuffer &buf, IBase
 		}
 		else
 		{
-			g_KeyValuesErrorStack.ReportError("LoadFromBuffer: missing {" );
+			g_KeyValuesErrorStack->ReportError("LoadFromBuffer: missing {" );
 		}
 
 		if ( !bAccepted )
@@ -2360,7 +2365,7 @@ bool KeyValues::LoadFromBuffer( char const *resourceName, CUtlBuffer &buf, IBase
 		}
 	}
 
-	g_KeyValuesErrorStack.SetFilename( "" );	
+	g_KeyValuesErrorStack->SetFilename( "" );	
 
 	return true;
 }
@@ -2405,7 +2410,7 @@ void KeyValues::RecursiveLoadFromBuffer( char const *resourceName, CUtlBuffer &b
 	bool wasConditional;
 	if ( errorReport.GetStackLevel() > 100 )
 	{
-		g_KeyValuesErrorStack.ReportError( "RecursiveLoadFromBuffer:  recursion overflow" );
+		g_KeyValuesErrorStack->ReportError( "RecursiveLoadFromBuffer:  recursion overflow" );
 		return;
 	}
 
@@ -2427,13 +2432,13 @@ void KeyValues::RecursiveLoadFromBuffer( char const *resourceName, CUtlBuffer &b
 
 		if ( !name )	// EOF stop reading
 		{
-			g_KeyValuesErrorStack.ReportError("RecursiveLoadFromBuffer:  got EOF instead of keyname" );
+			g_KeyValuesErrorStack->ReportError("RecursiveLoadFromBuffer:  got EOF instead of keyname" );
 			break;
 		}
 
 		if ( !*name ) // empty token, maybe "" or EOF
 		{
-			g_KeyValuesErrorStack.ReportError("RecursiveLoadFromBuffer:  got empty keyname" );
+			g_KeyValuesErrorStack->ReportError("RecursiveLoadFromBuffer:  got empty keyname" );
 			break;
 		}
 
@@ -2459,13 +2464,13 @@ void KeyValues::RecursiveLoadFromBuffer( char const *resourceName, CUtlBuffer &b
 
 		if ( !value )
 		{
-			g_KeyValuesErrorStack.ReportError("RecursiveLoadFromBuffer:  got NULL key" );
+			g_KeyValuesErrorStack->ReportError("RecursiveLoadFromBuffer:  got NULL key" );
 			break;
 		}
 		
 		if ( *value == '}' && !wasQuoted )
 		{
-			g_KeyValuesErrorStack.ReportError("RecursiveLoadFromBuffer:  got } in key" );
+			g_KeyValuesErrorStack->ReportError("RecursiveLoadFromBuffer:  got } in key" );
 			break;
 		}
 
@@ -2480,7 +2485,7 @@ void KeyValues::RecursiveLoadFromBuffer( char const *resourceName, CUtlBuffer &b
 		{
 			if ( wasConditional )
 			{
-				g_KeyValuesErrorStack.ReportError("RecursiveLoadFromBuffer:  got conditional between key and value" );
+				g_KeyValuesErrorStack->ReportError("RecursiveLoadFromBuffer:  got conditional between key and value" );
 				break;
 			}
 			

--- a/tier1/keyvalues.cpp
+++ b/tier1/keyvalues.cpp
@@ -30,11 +30,12 @@
 #include "utlqueue.h"
 #include "UtlSortVector.h"
 #include "convar.h"
+#include <memory>
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include <tier0/memdbgon.h>
 
-static const char * s_LastFileLoadingFrom = "unknown"; // just needed for error messages
+static thread_local const char * s_LastFileLoadingFrom = "unknown"; // just needed for error messages
 
 // Statics for the growable string table
 int (*KeyValues::s_pfGetSymbolForString)( const char *name, bool bCreate ) = &KeyValues::GetSymbolForStringClassic;
@@ -42,7 +43,7 @@ const char *(*KeyValues::s_pfGetStringForSymbol)( int symbol ) = &KeyValues::Get
 CKeyValuesGrowableStringTable *KeyValues::s_pGrowableStringTable = NULL;
 
 #define KEYVALUES_TOKEN_SIZE	4096
-static char s_pTokenBuf[KEYVALUES_TOKEN_SIZE];
+static thread_local std::unique_ptr<char[]> s_pTokenBuf(new char[KEYVALUES_TOKEN_SIZE]);
 
 
 #define INTERNALWRITE( pData, len ) InternalWrite( filesystem, f, pBuf, pData, len )
@@ -122,7 +123,7 @@ private:
 	const char *m_pFilename;
 	int		m_errorIndex;
 	int		m_maxErrorIndex;
-} g_KeyValuesErrorStack;
+} thread_local g_KeyValuesErrorStack;
 
 
 // a simple helper that creates stack entries as it goes in & out of scope
@@ -209,7 +210,7 @@ public:
 	CUtlVector< kve > keys;
 };
 
-static CLeakTrack track;
+static thread_local CLeakTrack track; // RaphaelIT7: Would probably be better to use a mutex or something... but it would be slower :sob:
 
 #define TRACK_KV_ADD( ptr, name )	track.AddKv( ptr, name )
 #define TRACK_KV_REMOVE( ptr )		track.RemoveKv( ptr )
@@ -559,22 +560,24 @@ const char *KeyValues::ReadToken( CUtlBuffer &buf, bool &wasQuoted, bool &wasCon
 	if ( !c )
 		return NULL;
 
+	char* pTokenBuf = s_pTokenBuf.get();
+
 	// read quoted strings specially
 	if ( *c == '\"' )
 	{
 		wasQuoted = true;
 		buf.GetDelimitedString( m_bHasEscapeSequences ? GetCStringCharConversion() : GetNoEscCharConversion(), 
-			s_pTokenBuf, KEYVALUES_TOKEN_SIZE );
-		return s_pTokenBuf;
+			pTokenBuf, KEYVALUES_TOKEN_SIZE );
+		return pTokenBuf;
 	}
 
 	if ( *c == '{' || *c == '}' )
 	{
 		// it's a control char, just add this one char and stop reading
-		s_pTokenBuf[0] = *c;
-		s_pTokenBuf[1] = 0;
+		pTokenBuf[0] = *c;
+		pTokenBuf[1] = 0;
 		buf.SeekGet( CUtlBuffer::SEEK_CURRENT, 1 );
-		return s_pTokenBuf;
+		return pTokenBuf;
 	}
 
 	// read in the token until we hit a whitespace or a control character
@@ -605,7 +608,7 @@ const char *KeyValues::ReadToken( CUtlBuffer &buf, bool &wasQuoted, bool &wasCon
 
 		if (nCount < (KEYVALUES_TOKEN_SIZE-1) )
 		{
-			s_pTokenBuf[nCount++] = *c;	// add char to buffer
+			pTokenBuf[nCount++] = *c;	// add char to buffer
 		}
 		else if ( !bReportedError )
 		{
@@ -615,8 +618,8 @@ const char *KeyValues::ReadToken( CUtlBuffer &buf, bool &wasQuoted, bool &wasCon
 
 		buf.SeekGet( CUtlBuffer::SEEK_CURRENT, 1 );
 	}
-	s_pTokenBuf[ nCount ] = 0;
-	return s_pTokenBuf;
+	pTokenBuf[ nCount ] = 0;
+	return pTokenBuf;
 }
 #pragma warning (default:4706)
 

--- a/tier1/keyvalues.cpp
+++ b/tier1/keyvalues.cpp
@@ -123,7 +123,9 @@ private:
 	const char *m_pFilename;
 	int		m_errorIndex;
 	int		m_maxErrorIndex;
-} thread_local g_KeyValuesErrorStack;
+};
+
+static thread_local auto g_KeyValuesErrorStack = std::make_unique<CKeyValuesErrorStack>();
 
 
 // a simple helper that creates stack entries as it goes in & out of scope
@@ -137,7 +139,7 @@ public:
 
 	~CKeyErrorContext()
 	{
-		g_KeyValuesErrorStack.Pop();
+		g_KeyValuesErrorStack.get()->Pop();
 	}
 	CKeyErrorContext( int symName )
 	{
@@ -145,7 +147,7 @@ public:
 	}
 	void Reset( int symName )
 	{
-		g_KeyValuesErrorStack.Reset( m_stackLevel, symName );
+		g_KeyValuesErrorStack.get()->Reset( m_stackLevel, symName );
 	}
 	int GetStackLevel() const
 	{
@@ -154,7 +156,7 @@ public:
 private:
 	void Init( int symName )
 	{
-		m_stackLevel = g_KeyValuesErrorStack.Push( symName );
+		m_stackLevel = g_KeyValuesErrorStack.get()->Push( symName );
 	}
 
 	int m_stackLevel;
@@ -613,7 +615,7 @@ const char *KeyValues::ReadToken( CUtlBuffer &buf, bool &wasQuoted, bool &wasCon
 		else if ( !bReportedError )
 		{
 			bReportedError = true;
-			g_KeyValuesErrorStack.ReportError(" ReadToken overflow" );
+			g_KeyValuesErrorStack.get()->ReportError(" ReadToken overflow" );
 		}
 
 		buf.SeekGet( CUtlBuffer::SEEK_CURRENT, 1 );
@@ -2242,7 +2244,7 @@ bool KeyValues::LoadFromBuffer( char const *resourceName, CUtlBuffer &buf, IBase
 	CUtlVector< KeyValues * > baseKeys;
 	bool wasQuoted;
 	bool wasConditional;
-	g_KeyValuesErrorStack.SetFilename( resourceName );	
+	g_KeyValuesErrorStack.get()->SetFilename( resourceName );	
 	do 
 	{
 		bool bAccepted = true;
@@ -2259,7 +2261,7 @@ bool KeyValues::LoadFromBuffer( char const *resourceName, CUtlBuffer &buf, IBase
 
 			if ( !s || *s == 0 )
 			{
-				g_KeyValuesErrorStack.ReportError("#include is NULL " );
+				g_KeyValuesErrorStack.get()->ReportError("#include is NULL " );
 			}
 			else
 			{
@@ -2275,7 +2277,7 @@ bool KeyValues::LoadFromBuffer( char const *resourceName, CUtlBuffer &buf, IBase
 
 			if ( !s || *s == 0 )
 			{
-				g_KeyValuesErrorStack.ReportError("#base is NULL " );
+				g_KeyValuesErrorStack.get()->ReportError("#base is NULL " );
 			}
 			else
 			{
@@ -2321,7 +2323,7 @@ bool KeyValues::LoadFromBuffer( char const *resourceName, CUtlBuffer &buf, IBase
 		}
 		else
 		{
-			g_KeyValuesErrorStack.ReportError("LoadFromBuffer: missing {" );
+			g_KeyValuesErrorStack.get()->ReportError("LoadFromBuffer: missing {" );
 		}
 
 		if ( !bAccepted )
@@ -2361,7 +2363,7 @@ bool KeyValues::LoadFromBuffer( char const *resourceName, CUtlBuffer &buf, IBase
 		}
 	}
 
-	g_KeyValuesErrorStack.SetFilename( "" );	
+	g_KeyValuesErrorStack.get()->SetFilename( "" );	
 
 	return true;
 }
@@ -2406,7 +2408,7 @@ void KeyValues::RecursiveLoadFromBuffer( char const *resourceName, CUtlBuffer &b
 	bool wasConditional;
 	if ( errorReport.GetStackLevel() > 100 )
 	{
-		g_KeyValuesErrorStack.ReportError( "RecursiveLoadFromBuffer:  recursion overflow" );
+		g_KeyValuesErrorStack.get()->ReportError( "RecursiveLoadFromBuffer:  recursion overflow" );
 		return;
 	}
 
@@ -2428,13 +2430,13 @@ void KeyValues::RecursiveLoadFromBuffer( char const *resourceName, CUtlBuffer &b
 
 		if ( !name )	// EOF stop reading
 		{
-			g_KeyValuesErrorStack.ReportError("RecursiveLoadFromBuffer:  got EOF instead of keyname" );
+			g_KeyValuesErrorStack.get()->ReportError("RecursiveLoadFromBuffer:  got EOF instead of keyname" );
 			break;
 		}
 
 		if ( !*name ) // empty token, maybe "" or EOF
 		{
-			g_KeyValuesErrorStack.ReportError("RecursiveLoadFromBuffer:  got empty keyname" );
+			g_KeyValuesErrorStack.get()->ReportError("RecursiveLoadFromBuffer:  got empty keyname" );
 			break;
 		}
 
@@ -2460,13 +2462,13 @@ void KeyValues::RecursiveLoadFromBuffer( char const *resourceName, CUtlBuffer &b
 
 		if ( !value )
 		{
-			g_KeyValuesErrorStack.ReportError("RecursiveLoadFromBuffer:  got NULL key" );
+			g_KeyValuesErrorStack.get()->ReportError("RecursiveLoadFromBuffer:  got NULL key" );
 			break;
 		}
 		
 		if ( *value == '}' && !wasQuoted )
 		{
-			g_KeyValuesErrorStack.ReportError("RecursiveLoadFromBuffer:  got } in key" );
+			g_KeyValuesErrorStack.get()->ReportError("RecursiveLoadFromBuffer:  got } in key" );
 			break;
 		}
 
@@ -2481,7 +2483,7 @@ void KeyValues::RecursiveLoadFromBuffer( char const *resourceName, CUtlBuffer &b
 		{
 			if ( wasConditional )
 			{
-				g_KeyValuesErrorStack.ReportError("RecursiveLoadFromBuffer:  got conditional between key and value" );
+				g_KeyValuesErrorStack.get()->ReportError("RecursiveLoadFromBuffer:  got conditional between key and value" );
 				break;
 			}
 			

--- a/tier1/keyvalues.cpp
+++ b/tier1/keyvalues.cpp
@@ -34,7 +34,7 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include <tier0/memdbgon.h>
 
-static const char * s_LastFileLoadingFrom = "unknown"; // just needed for error messages
+static thread_local const char * s_LastFileLoadingFrom = "unknown"; // just needed for error messages
 
 // Statics for the growable string table
 int (*KeyValues::s_pfGetSymbolForString)( const char *name, bool bCreate ) = &KeyValues::GetSymbolForStringClassic;
@@ -42,7 +42,7 @@ const char *(*KeyValues::s_pfGetStringForSymbol)( int symbol ) = &KeyValues::Get
 CKeyValuesGrowableStringTable *KeyValues::s_pGrowableStringTable = NULL;
 
 #define KEYVALUES_TOKEN_SIZE	4096
-static char s_pTokenBuf[KEYVALUES_TOKEN_SIZE];
+static thread_local char s_pTokenBuf[KEYVALUES_TOKEN_SIZE];
 
 
 #define INTERNALWRITE( pData, len ) InternalWrite( filesystem, f, pBuf, pData, len )
@@ -122,7 +122,7 @@ private:
 	const char *m_pFilename;
 	int		m_errorIndex;
 	int		m_maxErrorIndex;
-} g_KeyValuesErrorStack;
+} thread_local g_KeyValuesErrorStack;
 
 
 // a simple helper that creates stack entries as it goes in & out of scope
@@ -209,7 +209,7 @@ public:
 	CUtlVector< kve > keys;
 };
 
-static CLeakTrack track;
+static thread_local CLeakTrack track; // RaphaelIT7: Would probably be better to use a mutex or something... but it would be slower :sob:
 
 #define TRACK_KV_ADD( ptr, name )	track.AddKv( ptr, name )
 #define TRACK_KV_REMOVE( ptr )		track.RemoveKv( ptr )

--- a/tier1/premake5_create_project.lua
+++ b/tier1/premake5_create_project.lua
@@ -53,6 +53,10 @@ group("SourceSDK")
 		})
 		vpaths({["Source files/*"] = "*.cpp"})
 
+		if TIER0_PROJECTCALLBACK then
+			TIER0_PROJECTCALLBACK()
+		end
+
 		IncludeSDKLZMA()
 
 		filter("system:windows")

--- a/tier1/premake5_create_project.lua
+++ b/tier1/premake5_create_project.lua
@@ -53,8 +53,8 @@ group("SourceSDK")
 		})
 		vpaths({["Source files/*"] = "*.cpp"})
 
-		if TIER0_PROJECTCALLBACK then
-			TIER0_PROJECTCALLBACK()
+		if TIER1_PROJECTCALLBACK then
+			TIER1_PROJECTCALLBACK()
 		end
 
 		IncludeSDKLZMA()

--- a/tier1/premake5_create_project.lua
+++ b/tier1/premake5_create_project.lua
@@ -53,10 +53,6 @@ group("SourceSDK")
 		})
 		vpaths({["Source files/*"] = "*.cpp"})
 
-		if TIER1_PROJECTCALLBACK then
-			TIER1_PROJECTCALLBACK()
-		end
-
 		IncludeSDKLZMA()
 
 		filter("system:windows")


### PR DESCRIPTION
> [!IMPORTANT]
> Due to me having mixed up the patch branches a bit there may also be some older or duplicate changes?
> Just be caucious when reviewing :)
> Source for any new files will be: https://github.com/RaphaelIT7/obsolete-source-engine

[+] Added `te_bloodsprite`, `te_explosion`, `te_footprintdecal`, `te_largefunnel` headers for the classes.
[#] All network_test changes from GMod
[#] Updated `IPhysicsObject`, `IGameEvent`, `IServerGameClients`, `IGarrysMod`, `IGet`
-> For these, the virtual functions were changed.
[#] Initialize `DVariant` with a `nullptr`
[#] Made `DVariant::ToString` & `KeyValues` thread-safe
[#] Fixed physics_shared.h causing unnecessary errors when trying to use `IPhysicsSurfacePropsInternal`
-> I should probably make an #if to allow switching between `IPhysicsSurfacePropsInternal` and `IPhysicsSurfaceProps`
[#] Fixed my previous mess with `IBaseFileSystem` (turns out it isn't a `long long` for return values)
[#] Fixed linker error from `CThreadMutex::Lock()` as it's already inside tier0.lib
-> Same for `CThreadSpinRWLock::LockForWrite()` but only on 64x
[#] Fixed a crash with `ConVar::ChangeStringValue` when `g_pCVar` is `NULL`
[#] Fixed a few warnings in mathlib & `KeyValues::LoadFromFile`
[#] Fixed CBaseClient having wrong offsets on 32x due to `m_bInitialConVarsSet` not existing there.
[#] Exposed `ConVar_GetConVarFlag`, `ConVar_GetDLLIdentifier`, `ConVar_GetIsRegistered`, `ConVar_GetDefaultAccessor` & Added `TIER1_PROJECTCALLBACK`
-> I think I had this in a PR before? though I'm unsure-